### PR TITLE
Refactor type2 runner

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -9,13 +9,6 @@ install(
     DESTINATION lib/appimagelauncher COMPONENT APPIMAGELAUNCHER
 )
 
-# also, install the runtime, which is needed to run AppImages
-install(
-    FILES ${PROJECT_BINARY_DIR}/lib/AppImageKit/src/runtime
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-    DESTINATION lib/appimagelauncher COMPONENT APPIMAGELAUNCHER
-)
-
 # TODO: find alternative to the following "workaround" (a pretty dirty hack, actually...)
 # bundle update-binfmts as a fallback for distros which don't have it installed
 find_program(UPDATE_BINFMTS

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,3 @@
-# prevent magic bytes from being inserted into AppImage runtime
-set(APPIMAGEKIT_EMBED_MAGIC_BYTES OFF CACHE BOOL "" FORCE)
 # enable libbsd powered setting of proc title in the runtime when using $TARGET_APPIMAGE (which we do) in order to
 # allow users to distinguish between the AppImages run with the AppImageLauncher runtime
 set(APPIMAGEKIT_RUNTIME_ENABLE_SETPROCTITLE ON CACHE BOOL "" FORCE)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,9 @@ int runAppImage(const QString& pathToAppImage, int argc, char** argv) {
         return 1;
     }
 
+    // suppress desktop integration script
+    setenv("DESKTOPINTEGRATION", "AppImageLauncher", true);
+
     // build path to AppImage runtime
     // as it might error, check before fork()ing to be able to display an error message beforehand
     auto exeDir = QFileInfo(QFile("/proc/self/exe").symLinkTarget()).absoluteDir().absolutePath();
@@ -204,9 +207,6 @@ int runAppImage(const QString& pathToAppImage, int argc, char** argv) {
         // however, this requires some process management (e.g., killing all processes inside the AppImage and also
         // the FUSE "mount" process, when this application is killed...)
         setenv("TARGET_APPIMAGE", fullPathToAppImage.c_str(), true);
-
-        // suppress desktop integration script
-        setenv("DESKTOPINTEGRATION", "AppImageLauncher", true);
 
         // first attempt: find runtime in expected installation directory
         auto pathToRuntime = exeDir.toStdString() + "/../lib/appimagelauncher/runtime";


### PR DESCRIPTION
Closes #31. Related to #29 and #34.

At the moment, we can not merge this PR as we would break backwards compatibility for all type 2 AppImages that were built with an old runtime (pre-end-of-March, before https://github.com/AppImage/AppImageKit/pull/719 was merged).