### PR TITLE
 Fix argument forwarding broken since #73

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -193,8 +193,8 @@ int runAppImage(const QString& pathToAppImage, int argc, char** argv) {
         }
 
         // need a char pointer instead of a const one, therefore can't use .c_str()
-        std::vector<char> argv0Buffer(pathToRuntime.size() + 1, '\0');
-        strcpy(argv0Buffer.data(), pathToRuntime.c_str());
+        std::vector<char> argv0Buffer(pathToAppImage.toStdString().size() + 1, '\0');
+        strcpy(argv0Buffer.data(), pathToAppImage.toStdString().c_str());
 
         std::vector<char*> args;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,9 +149,7 @@ int runAppImage(const QString& pathToAppImage, int argc, char** argv) {
         args.push_back(argv0Buffer.data());
 
         // copy arguments
-        // starting at index 2, as the first argument is supposed to be the path to an AppImage
-        // all the other arguments can simply be copied
-        for (int i = 2; i < argc; i++) {
+        for (int i = 1; i < argc; i++) {
             args.push_back(argv[i]);
         }
 
@@ -201,9 +199,7 @@ int runAppImage(const QString& pathToAppImage, int argc, char** argv) {
         args.push_back(argv0Buffer.data());
 
         // copy arguments
-        // starting at index 2, as the first argument is supposed to be the path to an AppImage
-        // all the other arguments can simply be copied
-        for (int i = 2; i < argc; i++) {
+        for (int i = 1; i < argc; i++) {
             args.push_back(argv[i]);
         }
 

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -98,7 +98,7 @@ if [ "$BIONIC" == "" ]; then
     # bundle application
     export UPDATE_INFORMATION="gh-releases-zsync|TheAssassin|AppImageLauncher|AppImageLauncher*-$ARCH.AppImage.zsync"
 
-    ./linuxdeploy-x86_64.AppImage --init-appdir --appdir AppDir --plugin qt --output appimage
+    ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt --output appimage
 fi
 
 # move AppImages to old cwd


### PR DESCRIPTION
CC @azubieta. In #73 you introduced a line of code that prevents the first argument from being forwarded. I mentioned I was surprised that was necessary, as I was quite sure that wasn't happening.

I merged the PR, thinking that it fixed some big issue, but it turned out I was right at first, as in `runAppImage()`, the first argument was skipped when preparing the arguments from being passed to the target AppImage.

This PR removes the redundancy, and makes sure the first argument is forwarded again to the called AppImage. It's probably better to remove the first argument in `main()`, where the argument handling takes place. Therefore I fixed the two loops in `runAppImage()`.