### PR TITLE
Extract launcher and integration code into separate classes and create new UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cmake/GIT_COMMIT
 squashfs-root/
 *.qm
 resources/l10n/*
+CMakeLists.txt.user

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,9 @@ target_link_libraries(appimagelauncherd shared filesystemwatcher PkgConfig::glib
 # set binary runtime rpath to make sure the libappimage.so built and installed by this project is going to be used
 # by the installed binaries (be it the .deb, the AppImage, or whatever)
 # in order to make the whole install tree relocatable, a relative path is used
-set_target_properties(AppImageLauncher PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib/appimagelauncher")
-set_target_properties(appimagelauncherd PROPERTIES INSTALL_RPATH "\$ORIGIN/../lib/appimagelauncher")
+file(RELATIVE_PATH LIBS_INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin ${CMAKE_INSTALL_PREFIX}/lib/appimagelauncher)
+set_target_properties(AppImageLauncher PROPERTIES INSTALL_RPATH "\$ORIGIN/${LIBS_INSTALL_PATH}")
+set_target_properties(appimagelauncherd PROPERTIES INSTALL_RPATH "\$ORIGIN/${LIBS_INSTALL_PATH}")
 
 # add dependency on runtime to make sure it's built
 add_dependencies(AppImageLauncher runtime)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(filesystemwatcher PUBLIC Qt5::Core)
 target_include_directories(filesystemwatcher PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # main AppImageLauncher application
-add_executable(AppImageLauncher main.cpp)
+add_executable(AppImageLauncher launcher/main.cpp launcher/Launcher.cpp launcher/Launcher.h launcher/AppImageDesktopIntegrationManager.cpp launcher/AppImageDesktopIntegrationManager.h launcher/ui.h launcher/ui.cpp)
 target_link_libraries(AppImageLauncher shared PkgConfig::glib libappimage)
 
 # appimagelauncherd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(filesystemwatcher PUBLIC Qt5::Core)
 target_include_directories(filesystemwatcher PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # main AppImageLauncher application
-add_executable(AppImageLauncher launcher/main.cpp launcher/Launcher.cpp launcher/Launcher.h launcher/AppImageDesktopIntegrationManager.cpp launcher/AppImageDesktopIntegrationManager.h launcher/ui.h launcher/ui.cpp)
+add_executable(AppImageLauncher launcher/main.cpp launcher/Launcher.cpp launcher/Launcher.h launcher/AppImageDesktopIntegrationManager.cpp launcher/AppImageDesktopIntegrationManager.h launcher/ui.ui launcher/ui.h launcher/ui.cpp)
 target_link_libraries(AppImageLauncher shared PkgConfig::glib libappimage)
 
 # appimagelauncherd

--- a/src/launcher/AppImageDesktopIntegrationManager.cpp
+++ b/src/launcher/AppImageDesktopIntegrationManager.cpp
@@ -2,11 +2,16 @@
 // Created by alexis on 9/1/18.
 //
 
-#include <shared.h>
+// system includes
+#include <glib.h>
+
+// library includes
 #include <QDebug>
 #include <appimage/appimage.h>
-#include <glib.h>
-#include <translationmanager.h>
+
+// local includes
+#include "../shared.h"
+#include "../translationmanager.h"
 #include "AppImageDesktopIntegrationManager.h"
 
 bool AppImageDesktopIntegrationManager::isIntegrationRequired(const QString &appImagePath) {

--- a/src/launcher/AppImageDesktopIntegrationManager.cpp
+++ b/src/launcher/AppImageDesktopIntegrationManager.cpp
@@ -1,0 +1,95 @@
+//
+// Created by alexis on 9/1/18.
+//
+
+#include <shared.h>
+#include <QDebug>
+#include <appimage/appimage.h>
+#include <glib.h>
+#include <translationmanager.h>
+#include "AppImageDesktopIntegrationManager.h"
+
+bool AppImageDesktopIntegrationManager::isIntegrationRequired(const QString &appImagePath) {
+    return false;
+}
+
+void AppImageDesktopIntegrationManager::integrateAppImage(const QString &pathToAppImage) {
+    auto pathToIntegratedAppImage = buildDeploymentPath(pathToAppImage);
+
+    // check whether integration was successful
+    // need std::strings to get working pointers with .c_str()
+    const auto oldPath = pathToAppImage.toStdString();
+    const auto newPath = pathToIntegratedAppImage.toStdString();
+
+    // create target directory
+    QDir().mkdir(QFileInfo(QFile(pathToIntegratedAppImage)).dir().absolutePath());
+
+    // check whether AppImage is in integration directory already
+    if (QFileInfo(pathToAppImage).absoluteFilePath() != QFileInfo(pathToIntegratedAppImage).absoluteFilePath()) {
+        // need to check whether file exists
+        // if it does, the existing AppImage needs to be removed before rename can be called
+        if (QFile(pathToIntegratedAppImage).exists())
+            throw OverridingExistingAppImageFile("");
+
+        bool succeed = QFile::rename(pathToAppImage, pathToIntegratedAppImage);
+        qWarning() << QObject::tr("Unable to move %1 to %2, trying coping it instead.").arg(pathToAppImage,
+                                                                                            pathToIntegratedAppImage);
+        if (!succeed)
+            succeed = QFile::copy(pathToAppImage, pathToIntegratedAppImage);
+
+        if (!succeed)
+            throw IntegrationFailed(QObject::tr("Unable to move or copy AppImage to %1.")
+                                            .arg("$HOME/Applications").toStdString());
+    }
+
+    if (!installDesktopFile(pathToIntegratedAppImage, true))
+        throw IntegrationFailed(QObject::tr("Unable to install the AppImage Desktop File.").toStdString());
+
+    // make sure the icons in the launcher are refreshed
+    if (!updateDesktopDatabaseAndIconCaches())
+        throw IntegrationFailed(QObject::tr("Unable to update Desktop Database and/or Icons").toStdString());
+}
+
+QString AppImageDesktopIntegrationManager::buildDeploymentPath(const QString &pathToAppImage) {
+    // if type 2 AppImage, we can build a "content-aware" filename
+    // see #7 for details
+    auto digest = getAppImageDigestMd5(pathToAppImage);
+
+    const QFileInfo appImageInfo(pathToAppImage);
+
+    QString baseName = appImageInfo.completeBaseName();
+
+    // if digest is available, append a separator
+    if (!digest.isEmpty()) {
+        const auto digestSuffix = "_" + digest;
+
+        // check whether digest is already contained in filename
+        if (!pathToAppImage.contains(digestSuffix))
+            baseName += "_" + digest;
+    }
+
+    auto fileName = baseName;
+
+    // must not use completeSuffix() in combination with completeBasename(), otherwise the final filename is composed
+    // incorrectly
+    if (!appImageInfo.suffix().isEmpty()) {
+        fileName += "." + appImageInfo.suffix();
+    }
+
+    return integratedAppImagesDestination().path() + "/" + fileName;
+}
+
+bool AppImageDesktopIntegrationManager::hasAlreadyBeenIntegrated(const QString &pathToAppImage) {
+    return appimage_is_registered_in_system(pathToAppImage.toStdString().c_str());
+}
+
+bool AppImageDesktopIntegrationManager::installDesktopFile(const QString &pathToAppImage, bool resolveCollisions) {
+    return ::installDesktopFile(pathToAppImage, resolveCollisions);
+
+}
+
+void AppImageDesktopIntegrationManager::updateAppImage(const QString &pathToAppImage) {
+    bool result = ::updateDesktopFile(pathToAppImage);
+    if (!result)
+        throw IntegrationFailed(QObject::tr("Unable to update AppImage Desktop file.").toStdString());
+}

--- a/src/launcher/AppImageDesktopIntegrationManager.cpp
+++ b/src/launcher/AppImageDesktopIntegrationManager.cpp
@@ -29,7 +29,7 @@ void AppImageDesktopIntegrationManager::integrateAppImage(const QString &pathToA
         // need to check whether file exists
         // if it does, the existing AppImage needs to be removed before rename can be called
         if (QFile(pathToIntegratedAppImage).exists())
-            throw OverridingExistingAppImageFile("");
+            throw OverridingExistingFileError("");
 
         bool succeed = QFile::rename(pathToAppImage, pathToIntegratedAppImage);
         qWarning() << QObject::tr("Unable to move %1 to %2, trying coping it instead.").arg(pathToAppImage,
@@ -38,16 +38,16 @@ void AppImageDesktopIntegrationManager::integrateAppImage(const QString &pathToA
             succeed = QFile::copy(pathToAppImage, pathToIntegratedAppImage);
 
         if (!succeed)
-            throw IntegrationFailed(QObject::tr("Unable to move or copy AppImage to %1.")
+            throw IntegrationFailedError(QObject::tr("Unable to move or copy AppImage to %1.")
                                             .arg("$HOME/Applications").toStdString());
     }
 
     if (!installDesktopFile(pathToIntegratedAppImage, true))
-        throw IntegrationFailed(QObject::tr("Unable to install the AppImage Desktop File.").toStdString());
+        throw IntegrationFailedError(QObject::tr("Unable to install the AppImage Desktop File.").toStdString());
 
     // make sure the icons in the launcher are refreshed
     if (!updateDesktopDatabaseAndIconCaches())
-        throw IntegrationFailed(QObject::tr("Unable to update Desktop Database and/or Icons").toStdString());
+        throw IntegrationFailedError(QObject::tr("Unable to update Desktop Database and/or Icons").toStdString());
 }
 
 QString AppImageDesktopIntegrationManager::buildDeploymentPath(const QString &pathToAppImage) {
@@ -91,5 +91,5 @@ bool AppImageDesktopIntegrationManager::installDesktopFile(const QString &pathTo
 void AppImageDesktopIntegrationManager::updateAppImage(const QString &pathToAppImage) {
     bool result = ::updateDesktopFile(pathToAppImage);
     if (!result)
-        throw IntegrationFailed(QObject::tr("Unable to update AppImage Desktop file.").toStdString());
+        throw IntegrationFailedError(QObject::tr("Unable to update AppImage Desktop file.").toStdString());
 }

--- a/src/launcher/AppImageDesktopIntegrationManager.cpp
+++ b/src/launcher/AppImageDesktopIntegrationManager.cpp
@@ -14,10 +14,6 @@
 #include "../translationmanager.h"
 #include "AppImageDesktopIntegrationManager.h"
 
-bool AppImageDesktopIntegrationManager::isIntegrationRequired(const QString &appImagePath) {
-    return false;
-}
-
 void AppImageDesktopIntegrationManager::integrateAppImage(const QString &pathToAppImage) {
     auto pathToIntegratedAppImage = buildDeploymentPath(pathToAppImage);
 

--- a/src/launcher/AppImageDesktopIntegrationManager.h
+++ b/src/launcher/AppImageDesktopIntegrationManager.h
@@ -5,10 +5,11 @@
 #ifndef APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H
 #define APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H
 
-
+// system includes
 #include <stdexcept>
-#include <QString>
 
+// library includes
+#include <QString>
 
 class AppImageDesktopIntegrationManager {
 

--- a/src/launcher/AppImageDesktopIntegrationManager.h
+++ b/src/launcher/AppImageDesktopIntegrationManager.h
@@ -1,0 +1,55 @@
+//
+// Created by alexis on 9/1/18.
+//
+
+#ifndef APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H
+#define APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H
+
+
+#include <stdexcept>
+#include <QString>
+
+
+class AppImageDesktopIntegrationManager {
+
+public:
+    bool isIntegrationRequired(const QString &appImagePath);
+
+    void integrateAppImage(const QString &appImagePath);
+
+    QString buildDeploymentPath(const QString& pathToAppImage);
+
+    bool hasAlreadyBeenIntegrated(const QString& pathToAppImage);
+
+
+    bool installDesktopFile(const QString& pathToAppImage, bool resolveCollisions);
+
+    void updateAppImage(const QString& pathToAppImage);
+};
+
+
+class AppImageFileNotExists : public std::runtime_error {
+public:
+    explicit AppImageFileNotExists(const std::string &what) : runtime_error(what) {}
+};
+
+class InvalidAppImageFile : public std::runtime_error {
+public:
+    explicit InvalidAppImageFile(const std::string &what) : runtime_error(what) {}
+};
+
+class IntegrationFailed : public std::runtime_error {
+public:
+    explicit IntegrationFailed(const std::string &what) : runtime_error(what) {}
+};
+
+class UnsuportedAppImageType : public std::runtime_error {
+public:
+    explicit UnsuportedAppImageType(const std::string &what) : runtime_error(what) {}
+};
+
+class OverridingExistingAppImageFile : public std::runtime_error {
+public:
+    explicit OverridingExistingAppImageFile(const std::string &what) : runtime_error(what) {}
+};
+#endif //APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H

--- a/src/launcher/AppImageDesktopIntegrationManager.h
+++ b/src/launcher/AppImageDesktopIntegrationManager.h
@@ -14,8 +14,6 @@
 class AppImageDesktopIntegrationManager {
 
 public:
-    bool isIntegrationRequired(const QString &appImagePath);
-
     void integrateAppImage(const QString &appImagePath);
 
     QString buildDeploymentPath(const QString& pathToAppImage);

--- a/src/launcher/AppImageDesktopIntegrationManager.h
+++ b/src/launcher/AppImageDesktopIntegrationManager.h
@@ -28,28 +28,28 @@ public:
 };
 
 
-class AppImageFileNotExists : public std::runtime_error {
+class FileNotFoundError : public std::runtime_error {
 public:
-    explicit AppImageFileNotExists(const std::string &what) : runtime_error(what) {}
+    explicit FileNotFoundError(const std::string &what) : runtime_error(what) {}
 };
 
-class InvalidAppImageFile : public std::runtime_error {
+class InvalidAppImageError : public std::runtime_error {
 public:
-    explicit InvalidAppImageFile(const std::string &what) : runtime_error(what) {}
+    explicit InvalidAppImageError(const std::string &what) : runtime_error(what) {}
 };
 
-class IntegrationFailed : public std::runtime_error {
+class IntegrationFailedError : public std::runtime_error {
 public:
-    explicit IntegrationFailed(const std::string &what) : runtime_error(what) {}
+    explicit IntegrationFailedError(const std::string &what) : runtime_error(what) {}
 };
 
-class UnsuportedAppImageType : public std::runtime_error {
+class UnsupportedTypeError : public std::runtime_error {
 public:
-    explicit UnsuportedAppImageType(const std::string &what) : runtime_error(what) {}
+    explicit UnsupportedTypeError(const std::string &what) : runtime_error(what) {}
 };
 
-class OverridingExistingAppImageFile : public std::runtime_error {
+class OverridingExistingFileError : public std::runtime_error {
 public:
-    explicit OverridingExistingAppImageFile(const std::string &what) : runtime_error(what) {}
+    explicit OverridingExistingFileError(const std::string &what) : runtime_error(what) {}
 };
 #endif //APPIMAGELAUNCHER_APPIMAGEDESKTOPINTEGRATIONMANAGER_H

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -65,8 +65,7 @@ void Launcher::executeAppImage() {
 
     // first of all, chmod +x the AppImage file, otherwise execv() will complain
     if (!makeExecutable(fullPathToAppImage))
-        throw ExecutionFailed(QObject::tr("Unable to make the AppImage file executable: %1")
-                                      .arg(appImagePath).toStdString());
+        throw ExecutionFailedError(QObject::tr("Unable to make the AppImage file executable: %1").arg(appImagePath).toStdString());
 
     // build path to AppImage runtime
     // as it might error, check before fork()ing to be able to display an error message beforehand
@@ -76,15 +75,13 @@ void Launcher::executeAppImage() {
         QFile appImage(QString::fromStdString(fullPathToAppImage.toStdString()));
 
         if (!appImage.open(QIODevice::ReadOnly))
-            throw ExecutionFailed(QObject::tr("Not enough privileges to read the AppImage file: %1")
-                                          .arg(appImagePath).toStdString());
+            throw ExecutionFailedError(QObject::tr("Not enough privileges to read the AppImage file: %1").arg(appImagePath).toStdString());
 
         // copy AppImage to temp dir
         QTemporaryDir tempDir("/tmp/AppImageLauncher-type1-XXXXXX");
 
         if (!tempDir.isValid())
-            throw ExecutionFailed(QObject::tr("Unable to create temporary directory %1")
-                                          .arg(tempDir.path()).toStdString());
+            throw ExecutionFailedError(QObject::tr("Unable to create temporary directory %1").arg(tempDir.path()).toStdString());
 
         tempDir.setAutoRemove(true);
 
@@ -95,19 +92,19 @@ void Launcher::executeAppImage() {
 
         auto tempAppImagePath = QDir(tempDir.path()).absoluteFilePath(QFileInfo(appImage).fileName());
         if (!appImage.copy(tempAppImagePath))
-            throw ExecutionFailed(QObject::tr("Failed to create temporary copy of type 1 AppImage").toStdString());
+            throw ExecutionFailedError(QObject::tr("Failed to create temporary copy of type 1 AppImage").toStdString());
 
         QFile tempAppImage(tempAppImagePath);
 
         if (!tempAppImage.open(QFile::ReadWrite))
-            throw ExecutionFailed(QObject::tr("Failed to open temporary AppImage copy for writing").toStdString());
+            throw ExecutionFailedError(QObject::tr("Failed to open temporary AppImage copy for writing").toStdString());
 
         // nuke magic bytes
         if (!tempAppImage.seek(8))
-            throw ExecutionFailed(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
+            throw ExecutionFailedError(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
 
         if (tempAppImage.write(QByteArray(3, '\0')) != 3)
-            throw ExecutionFailed(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
+            throw ExecutionFailedError(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
 
         auto tempAppImageFileName = tempAppImage.fileName();
 
@@ -158,8 +155,7 @@ void Launcher::executeAppImage() {
 
         // if it can't be found in either location, display error and exit
         if (!QFile(QString::fromStdString(pathToRuntime)).exists())
-            throw ExecutionFailed(QObject::tr("runtime not found: no such file or directory: %1").arg(
-                    QString::fromStdString(pathToRuntime)).toStdString());
+            throw ExecutionFailedError(QObject::tr("runtime not found: no such file or directory: %1").arg(QString::fromStdString(pathToRuntime)).toStdString());
 
         // need a char pointer instead of a const one, therefore can't use .c_str()
         std::vector<char> argv0Buffer(appImagePath.toStdString().size() + 1, '\0');

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -24,6 +24,10 @@ const QString& Launcher::getAppImagePath() const {
 }
 
 void Launcher::setAppImagePath(const QString& appImagePath) {
+    // error check before value is stored
+    // throws exceptions in case of errors
+    Launcher::validateAppImage(appImagePath);
+
     Launcher::appImagePath = appImagePath;
 }
 
@@ -39,24 +43,24 @@ int Launcher::getAppImageType() const {
     return appImageType;
 }
 
-
-void Launcher::inspectAppImageFile() {
+void Launcher::validateAppImage(const QString& appImagePath) {
     if (appImagePath.isEmpty())
-        throw PathNotSetError("");
+        throw ValueError("AppImage path must not be empty");
 
     if (!QFile::exists(appImagePath))
         throw FileNotFoundError(appImagePath.toStdString());
 
-    validateAppImageType();
-}
+    const auto appImageType = appimage_get_type(appImagePath.toStdString().c_str(), false);
 
-void Launcher::validateAppImageType() {
-    appImageType = appimage_get_type(appImagePath.toStdString().c_str(), false);
     if (appImageType < 1)
-        throw InvalidAppImageError("");
+        throw InvalidAppImageError("Types < 0 don't exist");
 
     if (appImageType > 2)
-        throw UnsupportedTypeError("");
+        throw UnsupportedTypeError("Types > 2 don't exist or aren't supported yet");
+}
+
+void Launcher::validateAppImage() const {
+    Launcher::validateAppImage(appImagePath);
 }
 
 void Launcher::executeAppImage() {

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -1,18 +1,21 @@
 //
 // Created by alexis on 8/30/18.
 //
+
+// system includes
 extern "C" {
     #include "unistd.h"
 }
 
+// library includes
 #include <QFile>
 #include <QDebug>
 #include <QMessageBox>
 #include <QTemporaryDir>
-
 #include <appimage/appimage.h>
 
-#include <shared.h>
+// local includes
+#include "../shared.h"
 #include "Launcher.h"
 
 

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -29,6 +29,9 @@ void Launcher::setAppImagePath(const QString& appImagePath) {
     Launcher::validateAppImage(appImagePath);
 
     Launcher::appImagePath = appImagePath;
+
+    // also update AppImage type to not have to read the file more than once to get that data
+    Launcher::appImageType = appimage_get_type(appImagePath.toStdString().c_str(), false);
 }
 
 const std::vector<char*>& Launcher::getArgs() const {

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -1,0 +1,227 @@
+//
+// Created by alexis on 8/30/18.
+//
+extern  "C" {
+    #include "unistd.h"
+}
+
+#include <QFile>
+#include <QDebug>
+#include <QMessageBox>
+#include <QTemporaryDir>
+
+#include <appimage/appimage.h>
+
+#include <shared.h>
+#include "Launcher.h"
+
+
+const QString &Launcher::getAppImagePath() const {
+    return appImagePath;
+}
+
+void Launcher::setAppImagePath(const QString &appImagePath) {
+    Launcher::appImagePath = appImagePath;
+}
+
+const std::vector<char *> &Launcher::getArgs() const {
+    return args;
+}
+
+void Launcher::setArgs(const std::vector<char *> &args) {
+    Launcher::args = args;
+}
+
+int Launcher::getAppImageType() const {
+    return appImageType;
+}
+
+
+void Launcher::inspectAppImageFile() {
+    if (appImagePath.isEmpty())
+        throw AppImageFilePathNotSet("");
+
+    if (!QFile::exists(appImagePath))
+        throw AppImageFileNotExists(appImagePath.toStdString());
+
+    validateAppImageType();
+}
+
+void Launcher::validateAppImageType() {
+    appImageType = appimage_get_type(appImagePath.toStdString().c_str(), false);
+    if (appImageType < 1)
+        throw InvalidAppImageFile("");
+
+    if (appImageType > 2)
+        throw UnsuportedAppImageType("");
+}
+
+void Launcher::executeAppImage() {
+    // needs to be converted to std::string to be able to use c_str()
+    // when using QString and then .toStdString().c_str(), the std::string instance will be an rvalue, and the
+    // pointer returned by c_str() will be invalid
+    auto x = appImagePath.toStdString();
+    auto fullPathToAppImage = QFileInfo(appImagePath).absoluteFilePath();
+
+    // first of all, chmod +x the AppImage file, otherwise execv() will complain
+    if (!makeExecutable(fullPathToAppImage))
+        throw ExecutionFailed(QObject::tr("Unable to make the AppImage file executable: %1")
+                                      .arg(appImagePath).toStdString());
+
+    // build path to AppImage runtime
+    // as it might error, check before fork()ing to be able to display an error message beforehand
+    auto exeDir = QFileInfo(QFile("/proc/self/exe").symLinkTarget()).absoluteDir().absolutePath();
+
+    if (appImageType == 1) {
+        QFile appImage(QString::fromStdString(fullPathToAppImage.toStdString()));
+
+        if (!appImage.open(QIODevice::ReadOnly))
+            throw ExecutionFailed(QObject::tr("Not enough privileges to read the AppImage file: %1")
+                                          .arg(appImagePath).toStdString());
+
+        // copy AppImage to temp dir
+        QTemporaryDir tempDir("/tmp/AppImageLauncher-type1-XXXXXX");
+
+        if (!tempDir.isValid())
+            throw ExecutionFailed(QObject::tr("Unable to create temporary directory %1")
+                                          .arg(tempDir.path()).toStdString());
+
+        tempDir.setAutoRemove(true);
+
+        // TODO: Fin a better solution for this.
+        // copy AppImage to temporary directory to prevent an execution loop, i.e., when AIL would call
+        // the AppImage again, due to binfmt, the system would call AIL.
+        // see: https://github.com/TheAssassin/AppImageLauncher/issues/3
+
+        auto tempAppImagePath = QDir(tempDir.path()).absoluteFilePath(QFileInfo(appImage).fileName());
+        if (!appImage.copy(tempAppImagePath))
+            throw ExecutionFailed(QObject::tr("Failed to create temporary copy of type 1 AppImage").toStdString());
+
+        QFile tempAppImage(tempAppImagePath);
+
+        if (!tempAppImage.open(QFile::ReadWrite))
+            throw ExecutionFailed(QObject::tr("Failed to open temporary AppImage copy for writing").toStdString());
+
+        // nuke magic bytes
+        if (!tempAppImage.seek(8))
+            throw ExecutionFailed(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
+
+        if (tempAppImage.write(QByteArray(3, '\0')) != 3)
+            throw ExecutionFailed(QObject::tr("Failed to remove magic bytes from temporary AppImage copy").toStdString());
+
+        auto tempAppImageFileName = tempAppImage.fileName();
+
+        // actually _write_ changes
+        tempAppImage.close();
+
+        makeExecutable(tempAppImageFileName);
+
+        // need a char pointer instead of a const one, therefore can't use .c_str()
+        std::vector<char> argv0Buffer(tempAppImageFileName.size() + 1, '\0');
+        strcpy(argv0Buffer.data(), tempAppImageFileName.toStdString().c_str());
+
+        std::vector<char *> args;
+
+        args.push_back(argv0Buffer.data());
+
+        // copy arguments
+        for (int i = 1; i < args.size(); i++) {
+            args.push_back(args[i]);
+        }
+
+        // args need to be null terminated
+        args.push_back(nullptr);
+
+        execv(tempAppImageFileName.toStdString().c_str(), args.data());
+
+        const auto &error = errno;
+        qCritical() << QObject::tr("execv() failed: %1", "error message").arg(strerror(error));
+    } else if (appImageType == 2) {
+        // use external runtime _without_ magic bytes to run the AppImage
+        // the original idea was to use /lib64/ld-linux-x86_64.so to run AppImages, but it did complain about some
+        // violated ELF data, and refused to run the AppImage
+        // alternatively, the AppImage would have to be mounted by this application, and AppRun would need to be called
+        // however, this requires some process management (e.g., killing all processes inside the AppImage and also
+        // the FUSE "mount" process, when this application is killed...)
+        setenv("TARGET_APPIMAGE", fullPathToAppImage.toStdString().c_str(), true);
+
+        // suppress desktop integration script
+        setenv("DESKTOPINTEGRATION", "AppImageLauncher", true);
+
+        // first attempt: find runtime in expected installation directory
+        auto pathToRuntime = exeDir.toStdString() + "/../lib/appimagelauncher/runtime";
+
+        // next method: find runtime in expected build location
+        if (!QFile(QString::fromStdString(pathToRuntime)).exists()) {
+            pathToRuntime = exeDir.toStdString() + "/../lib/AppImageKit/src/runtime";
+        }
+
+        // if it can't be found in either location, display error and exit
+        if (!QFile(QString::fromStdString(pathToRuntime)).exists())
+            throw ExecutionFailed(QObject::tr("runtime not found: no such file or directory: %1").arg(
+                    QString::fromStdString(pathToRuntime)).toStdString());
+
+        // need a char pointer instead of a const one, therefore can't use .c_str()
+        std::vector<char> argv0Buffer(appImagePath.toStdString().size() + 1, '\0');
+        strcpy(argv0Buffer.data(), appImagePath.toStdString().c_str());
+
+        std::vector<char *> args;
+
+        args.push_back(argv0Buffer.data());
+
+        // copy arguments
+        for (int i = 1; i < args.size(); i++) {
+            args.push_back(args[i]);
+        }
+
+        // args need to be null terminated
+        args.push_back(nullptr);
+
+        execv(pathToRuntime.c_str(), args.data());
+
+        const auto &error = errno;
+        qInfo() << QObject::tr("execv() failed: %1").arg(strerror(error));
+    }
+}
+
+bool Launcher::shouldBeIgnored() {
+    bool result =
+            isAMountOrExtractOperation() &&
+            // check for X-AppImage-Integrate=false
+            appimage_shall_not_be_integrated(appImagePath.toStdString().c_str()) &&
+            // ignore terminal apps (fixes #2)
+            appimage_is_terminal_app(appImagePath.toStdString().c_str()) &&
+            // AppImages in AppImages are not supposed to be integrated
+            appImagePath.startsWith("/tmp/.mount_");
+
+    return result;
+}
+
+bool Launcher::isAMountOrExtractOperation() const {
+    // type 2 specific checks
+    if (appImageType == 2) {
+        // check parameters
+        {
+            for (auto &i : args) {
+                QString arg = i;
+
+                // reserved argument space
+                const QString prefix = "--appimage-";
+
+                if (arg.startsWith(prefix)) {
+                    // don't annoy users who try to mount or extract AppImages
+                    if (arg == prefix + "mount" || arg == prefix + "extract") {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void Launcher::setIntegrationManager(AppImageDesktopIntegrationManager *integrationManager) {
+    Launcher::integrationManager = integrationManager;
+}
+
+

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -224,4 +224,18 @@ void Launcher::setIntegrationManager(AppImageDesktopIntegrationManager *integrat
     Launcher::integrationManager = integrationManager;
 }
 
+void Launcher::integrateAppImage() {
+    integrationManager->integrateAppImage(appImagePath);
+    appImagePath = integrationManager->buildDeploymentPath(appImagePath);
+}
 
+void Launcher::overrideAppImageIntegration() {
+    auto targetPath = integrationManager->buildDeploymentPath(appImagePath);
+    trashBin->disposeAppImage(targetPath);
+
+    integrateAppImage();
+}
+
+void Launcher::setTrashBin(TrashBin *trashBin) {
+    Launcher::trashBin = trashBin;
+}

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -180,7 +180,7 @@ void Launcher::executeAppImage() {
         execv(pathToRuntime.c_str(), args.data());
 
         const auto &error = errno;
-        qInfo() << QObject::tr("execv() failed: %1").arg(strerror(error));
+        qWarning() << QObject::tr("execv() failed: %1").arg(strerror(error));
     }
 }
 

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -39,10 +39,10 @@ int Launcher::getAppImageType() const {
 
 void Launcher::inspectAppImageFile() {
     if (appImagePath.isEmpty())
-        throw AppImageFilePathNotSet("");
+        throw PathNotSetError("");
 
     if (!QFile::exists(appImagePath))
-        throw AppImageFileNotExists(appImagePath.toStdString());
+        throw FileNotFoundError(appImagePath.toStdString());
 
     validateAppImageType();
 }
@@ -50,10 +50,10 @@ void Launcher::inspectAppImageFile() {
 void Launcher::validateAppImageType() {
     appImageType = appimage_get_type(appImagePath.toStdString().c_str(), false);
     if (appImageType < 1)
-        throw InvalidAppImageFile("");
+        throw InvalidAppImageError("");
 
     if (appImageType > 2)
-        throw UnsuportedAppImageType("");
+        throw UnsupportedTypeError("");
 }
 
 void Launcher::executeAppImage() {

--- a/src/launcher/Launcher.cpp
+++ b/src/launcher/Launcher.cpp
@@ -1,7 +1,7 @@
 //
 // Created by alexis on 8/30/18.
 //
-extern  "C" {
+extern "C" {
     #include "unistd.h"
 }
 
@@ -16,19 +16,19 @@ extern  "C" {
 #include "Launcher.h"
 
 
-const QString &Launcher::getAppImagePath() const {
+const QString& Launcher::getAppImagePath() const {
     return appImagePath;
 }
 
-void Launcher::setAppImagePath(const QString &appImagePath) {
+void Launcher::setAppImagePath(const QString& appImagePath) {
     Launcher::appImagePath = appImagePath;
 }
 
-const std::vector<char *> &Launcher::getArgs() const {
+const std::vector<char*>& Launcher::getArgs() const {
     return args;
 }
 
-void Launcher::setArgs(const std::vector<char *> &args) {
+void Launcher::setArgs(const std::vector<char*>& args) {
     Launcher::args = args;
 }
 
@@ -120,7 +120,7 @@ void Launcher::executeAppImage() {
         std::vector<char> argv0Buffer(tempAppImageFileName.size() + 1, '\0');
         strcpy(argv0Buffer.data(), tempAppImageFileName.toStdString().c_str());
 
-        std::vector<char *> args;
+        std::vector<char*> args;
 
         args.push_back(argv0Buffer.data());
 
@@ -134,7 +134,7 @@ void Launcher::executeAppImage() {
 
         execv(tempAppImageFileName.toStdString().c_str(), args.data());
 
-        const auto &error = errno;
+        const auto& error = errno;
         qCritical() << QObject::tr("execv() failed: %1", "error message").arg(strerror(error));
     } else if (appImageType == 2) {
         // use external runtime _without_ magic bytes to run the AppImage
@@ -165,7 +165,7 @@ void Launcher::executeAppImage() {
         std::vector<char> argv0Buffer(appImagePath.toStdString().size() + 1, '\0');
         strcpy(argv0Buffer.data(), appImagePath.toStdString().c_str());
 
-        std::vector<char *> args;
+        std::vector<char*> args;
 
         args.push_back(argv0Buffer.data());
 
@@ -179,7 +179,7 @@ void Launcher::executeAppImage() {
 
         execv(pathToRuntime.c_str(), args.data());
 
-        const auto &error = errno;
+        const auto& error = errno;
         qWarning() << QObject::tr("execv() failed: %1").arg(strerror(error));
     }
 }
@@ -202,7 +202,7 @@ bool Launcher::isAMountOrExtractOperation() const {
     if (appImageType == 2) {
         // check parameters
         {
-            for (auto &i : args) {
+            for (auto& i : args) {
                 QString arg = i;
 
                 // reserved argument space
@@ -220,7 +220,7 @@ bool Launcher::isAMountOrExtractOperation() const {
     return false;
 }
 
-void Launcher::setIntegrationManager(AppImageDesktopIntegrationManager *integrationManager) {
+void Launcher::setIntegrationManager(AppImageDesktopIntegrationManager* integrationManager) {
     Launcher::integrationManager = integrationManager;
 }
 
@@ -236,6 +236,6 @@ void Launcher::overrideAppImageIntegration() {
     integrateAppImage();
 }
 
-void Launcher::setTrashBin(TrashBin *trashBin) {
+void Launcher::setTrashBin(TrashBin* trashBin) {
     Launcher::trashBin = trashBin;
 }

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -52,9 +52,9 @@ private:
 
 /* Exceptions that can be thrown from the Launcher methods. */
 
-class AppImageFilePathNotSet : public std::runtime_error {
+class PathNotSetError : public std::runtime_error {
 public:
-    explicit AppImageFilePathNotSet(const std::string &what) : runtime_error(what) {}
+    explicit PathNotSetError(const std::string &what) : runtime_error(what) {}
 };
 
 class ExecutionFailed : public std::runtime_error {

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -8,12 +8,14 @@
 #include <QString>
 #include <vector>
 #include "AppImageDesktopIntegrationManager.h"
+#include "../trashbin.h"
 
 class Launcher {
     QString appImagePath;
     std::vector<char *> args{};
     int appImageType{-1};
 
+    TrashBin *trashBin{nullptr};
     AppImageDesktopIntegrationManager *integrationManager{nullptr};
 
 public:
@@ -29,11 +31,18 @@ public:
 
     void setIntegrationManager(AppImageDesktopIntegrationManager *integrationManager);
 
+    void setTrashBin(TrashBin *trashBin);
+
     void inspectAppImageFile();
 
     bool shouldBeIgnored();
 
     void executeAppImage();
+
+    void overrideAppImageIntegration();
+
+public slots:
+    void integrateAppImage();
 
 private:
     void validateAppImageType();

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -57,9 +57,9 @@ public:
     explicit PathNotSetError(const std::string &what) : runtime_error(what) {}
 };
 
-class ExecutionFailed : public std::runtime_error {
+class ExecutionFailedError : public std::runtime_error {
 public:
-    explicit ExecutionFailed(const std::string &what) : runtime_error(what) {}
+    explicit ExecutionFailedError(const std::string &what) : runtime_error(what) {}
 };
 
 

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -24,7 +24,7 @@ class Launcher {
     AppImageDesktopIntegrationManager *integrationManager{nullptr};
 
 public:
-    const QString &getAppImagePath() const;
+    const QString& getAppImagePath() const;
 
     void setAppImagePath(const QString &appImagePath);
 
@@ -38,28 +38,28 @@ public:
 
     void setTrashBin(TrashBin *trashBin);
 
-    void inspectAppImageFile();
-
     bool shouldBeIgnored();
 
     void executeAppImage();
 
     void overrideAppImageIntegration();
 
+    void validateAppImage() const;
+
 public slots:
     void integrateAppImage();
 
 private:
-    void validateAppImageType();
+    static void validateAppImage(const QString& path);
 
     bool isAMountOrExtractOperation() const;
 };
 
 /* Exceptions that can be thrown from the Launcher methods. */
 
-class PathNotSetError : public std::runtime_error {
+class ValueError : public std::runtime_error {
 public:
-    explicit PathNotSetError(const std::string &what) : runtime_error(what) {}
+    explicit ValueError(const std::string &what) : runtime_error(what) {}
 };
 
 class ExecutionFailedError : public std::runtime_error {

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -1,0 +1,57 @@
+//
+// Created by alexis on 8/30/18.
+//
+
+#ifndef APPIMAGELAUNCHER_LAUNCHER_H
+#define APPIMAGELAUNCHER_LAUNCHER_H
+
+#include <QString>
+#include <vector>
+#include "AppImageDesktopIntegrationManager.h"
+
+class Launcher {
+    QString appImagePath;
+    std::vector<char *> args{};
+    int appImageType{-1};
+
+    AppImageDesktopIntegrationManager *integrationManager{nullptr};
+
+public:
+    const QString &getAppImagePath() const;
+
+    void setAppImagePath(const QString &appImagePath);
+
+    const std::vector<char *> &getArgs() const;
+
+    void setArgs(const std::vector<char *> &args);
+
+    int getAppImageType() const;
+
+    void setIntegrationManager(AppImageDesktopIntegrationManager *integrationManager);
+
+    void inspectAppImageFile();
+
+    bool shouldBeIgnored();
+
+    void executeAppImage();
+
+private:
+    void validateAppImageType();
+
+    bool isAMountOrExtractOperation() const;
+};
+
+/* Exceptions that can be thrown from the Launcher methods. */
+
+class AppImageFilePathNotSet : public std::runtime_error {
+public:
+    explicit AppImageFilePathNotSet(const std::string &what) : runtime_error(what) {}
+};
+
+class ExecutionFailed : public std::runtime_error {
+public:
+    explicit ExecutionFailed(const std::string &what) : runtime_error(what) {}
+};
+
+
+#endif //APPIMAGELAUNCHER_LAUNCHER_H

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -5,8 +5,13 @@
 #ifndef APPIMAGELAUNCHER_LAUNCHER_H
 #define APPIMAGELAUNCHER_LAUNCHER_H
 
-#include <QString>
+// system includes
 #include <vector>
+
+// library includes
+#include <QString>
+
+// local includes
 #include "AppImageDesktopIntegrationManager.h"
 #include "../trashbin.h"
 

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -132,16 +132,16 @@ int main(int argc, char **argv) {
     launcher.setTrashBin(&trashBin);
     try {
         launcher.inspectAppImageFile();
-    } catch (const AppImageFilePathNotSet &ex) {
+    } catch (const PathNotSetError&) {
         qCritical() << "Missing AppImagePath in Launcher class. I wasn't initialized properly.";
         return 1;
-    } catch (const InvalidAppImageFile &ex) {
+    } catch (const InvalidAppImageError&) {
         QMessageBox::critical(
                 nullptr,
                 QObject::tr("Error"),
                 QObject::tr("Not an AppImage: %1").arg(pathToAppImage));
         return 1;
-    } catch (const AppImageFileNotExists &ex) {
+    } catch (const FileNotFoundError&) {
         std::cout << QObject::tr("Error: no such file or directory: %1").arg(pathToAppImage).toStdString() << std::endl;
         return 1;
     }

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -131,8 +131,8 @@ int main(int argc, char **argv) {
     launcher.setIntegrationManager(&integrationManager);
     launcher.setTrashBin(&trashBin);
     try {
-        launcher.inspectAppImageFile();
-    } catch (const PathNotSetError&) {
+        launcher.validateAppImage();
+    } catch (const ValueError&) {
         qCritical() << "Missing AppImagePath in Launcher class. I wasn't initialized properly.";
         return 1;
     } catch (const InvalidAppImageError&) {

--- a/src/launcher/main.cpp
+++ b/src/launcher/main.cpp
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
         // AppImages in AppImages are not supposed to be integrated
         if (pathToAppImage.startsWith("/tmp/.mount_"))
             launcher.executeAppImage();
-    } catch (const ExecutionFailed&) {
+    } catch (const ExecutionFailedError&) {
         qCritical() << QObject::tr("Failed to execute AppImage: %1").arg(pathToAppImage);
         return 1;
     }
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
 
                 try {
                     launcher.executeAppImage();
-                } catch (const ExecutionFailed&) {
+                } catch (const ExecutionFailedError&) {
                     qCritical() << QObject::tr("Failed to execute AppImage: %1").arg(pathToAppImage);
                     return 1;
                 }
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
 
                 try {
                     launcher.executeAppImage();
-                } catch (const ExecutionFailed&) {
+                } catch (const ExecutionFailedError&) {
                     qCritical() << QObject::tr("Failed to execute AppImage: %1").arg(pathToAppImage);
                     return 1;
                 }
@@ -258,7 +258,7 @@ int main(int argc, char **argv) {
 
             try {
                 launcher.executeAppImage();
-            } catch (const ExecutionFailed&) {
+            } catch (const ExecutionFailedError&) {
                 qCritical() << QObject::tr("Failed to execute AppImage: %1").arg(pathToAppImage);
                 return 1;
             }

--- a/src/launcher/ui.cpp
+++ b/src/launcher/ui.cpp
@@ -1,38 +1,78 @@
-#include <sstream>
 #include <QtWidgets/QMessageBox>
+#include <sstream>
 #include "ui.h"
+#include "ui_ui.h"
 
-UI::UI() {
+UI::UI(QWidget *parent) :
+        QDialog(parent),
+        ui(new Ui::UI) {
+    ui->setupUi(this);
+}
 
+UI::~UI() {
+    delete ui;
 }
 
 void UI::askIfAppImageFileShouldBeOverridden() {
     std::ostringstream message;
     message << QObject::tr("AppImage with same filename has already been integrated.").toStdString() << std::endl
             << std::endl
-            << QObject::tr("Do you wish to overwrite the existing AppImage?").toStdString() << std::endl
-            << QObject::tr(
-                    "Choosing No will run the AppImage once, and leave the system in its current state.").toStdString();
+            << QObject::tr("Do you wish to overwrite the existing AppImage?").toStdString() << std::endl;
 
     auto rv = QMessageBox::warning(
-            nullptr,
+            this,
             QObject::tr("Warning"),
             QString::fromStdString(message.str()),
             QMessageBox::Yes | QMessageBox::No,
             QMessageBox::Yes
     );
 
-    if (rv == QMessageBox::No)
-            emit dontOverrideAppImageFile();
-    else
-            emit overrideAppImageFile();
+    if (rv == QMessageBox::Yes) {
+        try {
+            launcher->overrideAppImageIntegration();
+            showCompletionPage();
+        } catch (const std::runtime_error &ex) {
+            notifyError(ex);
+        }
+    }
 }
 
-void UI::alertIntegrationFailed(const IntegrationFailed &ex) {
+void UI::notifyError(const std::runtime_error &ex) {
     QMessageBox::critical(
-            nullptr,
+            this,
             QObject::tr("Error"),
             ex.what()
     );
-    emit alertIntegrationFailedCompleted();
+}
+
+void UI::setLauncher(Launcher *launcher) {
+    UI::launcher = launcher;
+}
+
+void UI::showIntegrationPage() {
+    ui->stackedWidget->setCurrentWidget(ui->integrationPage);
+    connect(ui->integrateButton, &QPushButton::released, this, &UI::handleIntegrationRequested);
+    connect(ui->runButton, &QPushButton::released, this, &UI::handleExecutionRequested);
+    show();
+}
+
+void UI::showCompletionPage() {
+    ui->stackedWidget->setCurrentWidget(ui->completionPage);
+    connect(ui->runButton2, &QPushButton::released, this, &UI::handleExecutionRequested);
+    show();
+}
+
+void UI::handleIntegrationRequested() {
+    try {
+        launcher->integrateAppImage();
+        showCompletionPage();
+    } catch (const IntegrationFailed &ex) {
+        notifyError(ex);
+    } catch (const OverridingExistingAppImageFile &) {
+        askIfAppImageFileShouldBeOverridden();
+    }
+}
+
+void UI::handleExecutionRequested() {
+    launcher->executeAppImage();
 }

--- a/src/launcher/ui.cpp
+++ b/src/launcher/ui.cpp
@@ -1,0 +1,38 @@
+#include <sstream>
+#include <QtWidgets/QMessageBox>
+#include "ui.h"
+
+UI::UI() {
+
+}
+
+void UI::askIfAppImageFileShouldBeOverridden() {
+    std::ostringstream message;
+    message << QObject::tr("AppImage with same filename has already been integrated.").toStdString() << std::endl
+            << std::endl
+            << QObject::tr("Do you wish to overwrite the existing AppImage?").toStdString() << std::endl
+            << QObject::tr(
+                    "Choosing No will run the AppImage once, and leave the system in its current state.").toStdString();
+
+    auto rv = QMessageBox::warning(
+            nullptr,
+            QObject::tr("Warning"),
+            QString::fromStdString(message.str()),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::Yes
+    );
+
+    if (rv == QMessageBox::No)
+            emit dontOverrideAppImageFile();
+    else
+            emit overrideAppImageFile();
+}
+
+void UI::alertIntegrationFailed(const IntegrationFailed &ex) {
+    QMessageBox::critical(
+            nullptr,
+            QObject::tr("Error"),
+            ex.what()
+    );
+    emit alertIntegrationFailedCompleted();
+}

--- a/src/launcher/ui.cpp
+++ b/src/launcher/ui.cpp
@@ -66,9 +66,9 @@ void UI::handleIntegrationRequested() {
     try {
         launcher->integrateAppImage();
         showCompletionPage();
-    } catch (const IntegrationFailed &ex) {
+    } catch (const IntegrationFailedError& ex) {
         notifyError(ex);
-    } catch (const OverridingExistingAppImageFile &) {
+    } catch (const OverridingExistingFileError&) {
         askIfAppImageFileShouldBeOverridden();
     }
 }

--- a/src/launcher/ui.cpp
+++ b/src/launcher/ui.cpp
@@ -1,6 +1,13 @@
-#include <QtWidgets/QMessageBox>
+// system includes
 #include <sstream>
+
+// library includes
+#include <QtWidgets/QMessageBox>
+
+// local includes
 #include "ui.h"
+
+// Qt auto-generated includes
 #include "ui_ui.h"
 
 UI::UI(QWidget *parent) :

--- a/src/launcher/ui.h
+++ b/src/launcher/ui.h
@@ -1,0 +1,24 @@
+#ifndef UI_H
+#define UI_H
+
+#include <QObject>
+#include "AppImageDesktopIntegrationManager.h"
+
+class UI : public QObject {
+Q_OBJECT
+public:
+    UI();
+
+    void askIfAppImageFileShouldBeOverridden();
+
+    void alertIntegrationFailed(const IntegrationFailed &ex);
+signals:
+
+    void overrideAppImageFile();
+
+    void dontOverrideAppImageFile();
+
+    void alertIntegrationFailedCompleted();
+};
+
+#endif // UI_H

--- a/src/launcher/ui.h
+++ b/src/launcher/ui.h
@@ -1,7 +1,10 @@
 #ifndef UI_H
 #define UI_H
 
+// library includes
 #include <QDialog>
+
+// local includes
 #include "AppImageDesktopIntegrationManager.h"
 #include "Launcher.h"
 

--- a/src/launcher/ui.h
+++ b/src/launcher/ui.h
@@ -1,24 +1,43 @@
 #ifndef UI_H
 #define UI_H
 
-#include <QObject>
+#include <QDialog>
 #include "AppImageDesktopIntegrationManager.h"
+#include "Launcher.h"
 
-class UI : public QObject {
+namespace Ui {
+    class UI;
+}
+
+class UI : public QDialog {
 Q_OBJECT
+
+    Launcher *launcher{nullptr};
+
 public:
-    UI();
+
+    explicit UI(QWidget *parent = 0);
+
+    ~UI();
+
+    void setLauncher(Launcher *launcher);
 
     void askIfAppImageFileShouldBeOverridden();
 
-    void alertIntegrationFailed(const IntegrationFailed &ex);
-signals:
+    void notifyError(const std::runtime_error &ex);
 
-    void overrideAppImageFile();
+    void showIntegrationPage();
 
-    void dontOverrideAppImageFile();
+    void showCompletionPage();
 
-    void alertIntegrationFailedCompleted();
+protected slots:
+
+    void handleIntegrationRequested();
+
+    void handleExecutionRequested();
+
+private:
+    Ui::UI *ui;
 };
 
 #endif // UI_H

--- a/src/launcher/ui.ui
+++ b/src/launcher/ui.ui
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UI</class>
+ <widget class="QDialog" name="UI">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QStackedWidget" name="stackedWidget">
+     <widget class="QWidget" name="integrationPage">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>349</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="2">
+        <widget class="QPushButton" name="runButton">
+         <property name="text">
+          <string>Run</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Integrating it will move the AppImage into a predefined location, and include it in your application launcher.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="integrateButton">
+         <property name="text">
+          <string>Integrate</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="completionPage">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="1" column="1">
+        <widget class="QPushButton" name="runButton2">
+         <property name="text">
+          <string>Run</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="successLabel">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Integration completed successfully.&lt;/p&gt;&lt;p&gt;To remove or update the AppImage, please use the context menu of the application icon in your task bar or launcher.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
The title's a bit long, I have to admit. This is the first portion of the changes @azubieta provided in #89.

The PR extracts the launcher UI into a separate class which will encapsulate UI related code. That decouples it from the "business logic" (the main integration workflow), and begins to implement the Single Responsibility Principle.

I'm reviewing the changes and will publish a few more fixes before merging this PR.