### PR TITLE
Do not build AppImages any more

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,6 @@ Other systems derived from the listed ones, such as for instance Linux Mint (Ubu
 **Note:** If your system is not listed above as supported, please feel free to request support in an issue on GitHub. We can then discuss adding support.   
 
 
-### AppImage
-
-For evaluation purposes, you can download an AppImage from the [release page](https://github.com/TheAssassin/AppImageLauncher/releases), which will demonstrate how AppImageLauncher works. Please beware that certain features, like the removal of AppImages, require AppImageLauncher to be installed system wide.
-
-
 ## How it works
 
 AppImageLauncher is responsible for the desktop integration. When the user launches an AppImage, the software checks whether the AppImage has been integrated already. If not, it displays a dialog prompting the user whether to run the AppImage once, or move it to a predefined location and adding it to the application menus, launchers, etc.

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -51,7 +51,7 @@ make
 # build Debian package
 cpack -V -G DEB
 
-# skip RPM and AppImage build on bionic
+# skip RPM and source tarball build on bionic
 if [ "$BIONIC" == "" ]; then
     # build RPM package
     cpack -V -G RPM
@@ -59,54 +59,13 @@ if [ "$BIONIC" == "" ]; then
     # build source tarball
     # generates a lot of output, therefore not run in verbose mode
     cpack --config CPackSourceConfig.cmake
-
-    # build AppImage
-    # create AppDir
-    mkdir -p AppDir
-
-    # install to AppDir
-    make install DESTDIR=AppDir
-
-    # determine Git commit ID
-    # linuxdeployqt uses this for naming the file
-    export VERSION="git"$(cd "$REPO_ROOT" && date +%Y%m%d -u -d "$(git show -s --format=%ci $(git rev-parse HEAD))").$(cd "$REPO_ROOT" && git rev-parse --short HEAD)
-
-    # prepend Travis build number if possible
-    if [ "$TRAVIS_BUILD_NUMBER" != "" ]; then
-        export VERSION="travis$TRAVIS_BUILD_NUMBER-$VERSION"
-    fi
-
-    # remove other unnecessary data
-    find AppDir -type f -iname '*.a' -delete
-    rm -rf AppDir/usr/include
-
-
-    # get linuxdeployqt
-    wget https://github.com/TheAssassin/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-    wget https://github.com/TheAssassin/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
-    chmod +x linuxdeploy*-x86_64.AppImage
-
-    find AppDir/
-
-    unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-
-    # fix for trusty: default qmake is for qt4
-    if [ -x /usr/lib/x86_64-linux-gnu/qt5/bin/qmake ]; then
-        export QMAKE="/usr/lib/x86_64-linux-gnu/qt5/bin/qmake"
-    fi
-
-    # bundle application
-    export UPDATE_INFORMATION="gh-releases-zsync|TheAssassin|AppImageLauncher|AppImageLauncher*-$ARCH.AppImage.zsync"
-
-    ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt --output appimage
 fi
 
 # move AppImages to old cwd
 if [ "$BIONIC" == "" ]; then
-    mv AppImageLauncher*.AppImage* appimagelauncher*.{deb,rpm}* appimagelauncher*.tar* "$OLD_CWD"/
+    mv appimagelauncher*.{deb,rpm}* appimagelauncher*.tar* "$OLD_CWD"/
 else
     mv appimagelauncher*.deb* "$OLD_CWD"/
-
 fi
 
 popd


### PR DESCRIPTION
The AppImages were only there for evaluation ("try it out") purposes. That was clearly stated in the README, but some people ignored that. In order to avoid any further confusion, this PR removes the AppImage creation from the build script.