### PR TITLE
Fix service type in appimagelauncherfs

### DIFF
--- a/resources/appimagelauncherfs.service.in
+++ b/resources/appimagelauncherfs.service.in
@@ -3,7 +3,7 @@ Description=AppImageLauncherFS daemon
 Before=display-manager.service
 
 [Service]
-Type=Exec
+Type=exec
 ExecStart=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/appimagelauncherfs
 Restart=always
 RestartSec=2


### PR DESCRIPTION
Although it would be strange that `Exec` and `exec` would result in different systemd behavior, it does make (some) sense to use the syntax referred to in systemd's changelog: https://github.com/systemd/systemd/blob/master/NEWS#L103.

This would fix https://github.com/TheAssassin/AppImageLauncher/issues/122.