### PR TITLE
First run dialog

### DIFF
--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -189,6 +189,9 @@ void displayWarning(const QString& message) {
 QDir integratedAppImagesDestination() {
     auto config = getConfig();
 
+    if (config == nullptr)
+        return DEFAULT_INTEGRATION_DESTINATION;
+
     static const QString keyName("AppImageLauncher/destination");
     if (config->contains(keyName))
         return config->value(keyName).toString();

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -92,7 +92,16 @@ QString expandTilde(QString path) {
     return path;
 }
 
-void createDefaultConfig(const QString& configFilePath) {
+// calculate path to config file
+QString getConfigFilePath() {
+    const auto configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    const auto configFilePath = configPath + "/appimagelauncher.cfg";
+    return configFilePath;
+}
+
+void createDefaultConfig() {
+    auto configFilePath = getConfigFilePath();
+
     QFile file(configFilePath);
     file.open(QIODevice::WriteOnly);
     file.write("[AppImageLauncher]\n"
@@ -102,9 +111,7 @@ void createDefaultConfig(const QString& configFilePath) {
 
 
 std::shared_ptr<QSettings> getConfig() {
-    // calculate path to config file
-    const auto configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
-    const auto configFilePath = configPath + "/appimagelauncher.cfg";
+    auto configFilePath = getConfigFilePath();
 
     // if the file does not exist, we'll just use the standard location
     // while in theory it would have been possible to just write the default location to the file, if we'd ever change

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -99,7 +99,7 @@ QString getConfigFilePath() {
     return configFilePath;
 }
 
-void createDefaultConfig() {
+void createDefaultConfigFile() {
     auto configFilePath = getConfigFilePath();
 
     QFile file(configFilePath);
@@ -119,7 +119,7 @@ std::shared_ptr<QSettings> getConfig() {
     // the situation
     // therefore, the file is simply created, but left empty intentionally
     if (!QFileInfo::exists(configFilePath)) {
-        createDefaultConfig(configFilePath);
+        return nullptr;
     }
 
     auto rv = std::make_shared<QSettings>(configFilePath, QSettings::IniFormat);

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -99,14 +99,47 @@ QString getConfigFilePath() {
     return configFilePath;
 }
 
-void createDefaultConfigFile() {
+void createConfigFile(int askToMove, QString destination, int enableDaemon) {
     auto configFilePath = getConfigFilePath();
 
     QFile file(configFilePath);
     file.open(QIODevice::WriteOnly);
-    file.write("[AppImageLauncher]\n"
-               "# destination = ~/Applications\n"
-               "# enable_daemon = true\n");
+
+    // cannot use QSettings because it doesn't support comments
+    // let's do it manually and hope for the best
+    file.write("[AppImageLauncher]\n");
+
+    if (askToMove < 0) {
+        file.write("# ask_to_move = true\n");
+    } else {
+        file.write("ask_to_move = ");
+        if (askToMove == 0) {
+            file.write("false");
+        } else {
+            file.write("true");
+        }
+        file.write("\n");
+    }
+
+    if (destination.isEmpty()) {
+        file.write("# destination = ~/Applications\n");
+    } else {
+        file.write("destination = ");
+        file.write(destination.toUtf8());
+        file.write("\n");
+    }
+
+    if (enableDaemon < 0) {
+        file.write("# enable_daemon = true\n");
+    } else {
+        file.write("enable_daemon = ");
+        if (enableDaemon == 0) {
+            file.write("false");
+        } else {
+            file.write("true");
+        }
+        file.write("\n");
+    }
 }
 
 

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -92,6 +92,15 @@ QString expandTilde(QString path) {
     return path;
 }
 
+void createDefaultConfig(const QString& configFilePath) {
+    QFile file(configFilePath);
+    file.open(QIODevice::WriteOnly);
+    file.write("[AppImageLauncher]\n"
+               "# destination = ~/Applications\n"
+               "# enable_daemon = true\n");
+}
+
+
 std::shared_ptr<QSettings> getConfig() {
     // calculate path to config file
     const auto configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
@@ -103,11 +112,7 @@ std::shared_ptr<QSettings> getConfig() {
     // the situation
     // therefore, the file is simply created, but left empty intentionally
     if (!QFileInfo::exists(configFilePath)) {
-        QFile file(configFilePath);
-        file.open(QIODevice::WriteOnly);
-        file.write("[AppImageLauncher]\n"
-                   "# destination = ~/Applications\n"
-                   "# enable_daemon = true\n");
+        createDefaultConfig(configFilePath);
     }
 
     auto rv = std::make_shared<QSettings>(configFilePath, QSettings::IniFormat);

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -53,6 +53,10 @@ bool updateDesktopDatabaseAndIconCaches();
 // integrates an AppImage using a standard workflow used across all AppImageLauncher applications
 IntegrationState integrateAppImage(const QString& pathToAppImage, const QString& pathToIntegratedAppImage);
 
+// initialize config file with default contents
+// call only when the file doesn't exist
+void createDefaultConfigFile();
+
 // load config file and return it
 std::shared_ptr<QSettings> getConfig();
 

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -53,9 +53,11 @@ bool updateDesktopDatabaseAndIconCaches();
 // integrates an AppImage using a standard workflow used across all AppImageLauncher applications
 IntegrationState integrateAppImage(const QString& pathToAppImage, const QString& pathToIntegratedAppImage);
 
-// initialize config file with default contents
-// call only when the file doesn't exist
-void createDefaultConfigFile();
+// write config file to standard location with given configuration values
+// askToMove and enableDaemon both are bools but represented as int to add some sort of "unset" state
+// < 0: unset; 0 = false; > 0 = true
+// destination is a string that, when empty, will be interpreted as "use default"
+void createConfigFile(int askToMove, QString destination, int enableDaemon);
 
 // load config file and return it
 std::shared_ptr<QSettings> getConfig();

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 # main AppImageLauncher application
-add_executable(AppImageLauncher main.cpp resources.qrc)
+add_executable(AppImageLauncher main.cpp resources.qrc first-run.cpp first-run.h first-run.ui)
 target_link_libraries(AppImageLauncher shared PkgConfig::glib libappimage shared)
 
 # set binary runtime rpath to make sure the libappimage.so built and installed by this project is going to be used

--- a/src/ui/first-run.cpp
+++ b/src/ui/first-run.cpp
@@ -158,6 +158,4 @@ void showFirstRunDialog() {
     }
 
     dialog->writeConfigFile();
-
-    throw std::runtime_error("bla");
 }

--- a/src/ui/first-run.cpp
+++ b/src/ui/first-run.cpp
@@ -1,0 +1,163 @@
+// system includes
+#include <stdexcept>
+
+// library includes
+#include <QDesktopServices>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QDebug>
+#include <QFileDialog>
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QGraphicsPixmapItem>
+#include <QImage>
+#include <QLayout>
+#include <QStyle>
+#include <QUrl>
+
+// local includes
+#include "ui_first-run.h"
+#include "shared.h"
+
+
+class FirstRunDialog : public QDialog {
+private:
+    Ui::FirstRunDialog* firstRunDialog{};
+
+    // stores custom destination dir for AppImages
+    // if this is empty, the default value (defined in-code, might change over time) will be chosen
+    // the default will not be written to the config file, hence we need a way to detect that state, and it's assumed
+    // that when this string is empty, that's the case
+    // we could also just compare this directory with the default value just before saving, but IMO it's more obvious
+    // to the user that the "default" state is lost after having saved something with the "choose" button in a file
+    // dialog
+    QString destinationDir;
+
+private Q_SLOTS:
+    void resetDefaults() {
+        firstRunDialog->askMoveCheckBox->setChecked(true);
+
+        destinationDir = "";
+        updateDestinationDirLabel();
+    }
+
+    void handleButtonClicked(QAbstractButton* button) {
+        if (button == firstRunDialog->buttonBox->button(QDialogButtonBox::RestoreDefaults)) {
+            qDebug() << "restore defaults";
+            resetDefaults();
+        } else if (button == firstRunDialog->buttonBox->button(QDialogButtonBox::Help)) {
+            qDebug() << "help";
+            QDesktopServices::openUrl(QUrl("https://github.com/TheAssassin/AppImageLauncher/wiki/First-run"));
+
+        } else {
+            qDebug() << "unknown button clicked" << button;
+        }
+    }
+
+    void handleAskMoveCheckBoxStateChange(int state) {
+        qDebug() << "new ask move check box state" << state;
+
+        // this alone unfortunately doesn't do the trick...
+        for (auto* layout : {
+            static_cast<QLayout*>(firstRunDialog->destDirVertLayout),
+            static_cast<QLayout*>(firstRunDialog->destDirHorLayout),
+        }) {
+            layout->setEnabled(state > 0);
+        }
+
+        // have to also manually enable/disable all the
+        for (auto* label : {
+            static_cast<QWidget*>(firstRunDialog->destinationDirDescLabel),
+            static_cast<QWidget*>(firstRunDialog->destinationDirLabel),
+            static_cast<QWidget*>(firstRunDialog->customizeIntegrationDirButton),
+        }) {
+            label->setEnabled(state > 0);
+        }
+    }
+
+    void handleCustomizeIntegrationDirButtonClicked(bool checked = false) {
+        (void) checked;
+
+        auto oldDir = destinationDir;
+        if (oldDir.isEmpty())
+            oldDir = integratedAppImagesDestination().absolutePath();
+
+        auto newDir = QFileDialog::getExistingDirectory(this, tr("Choose integration destination dir"), oldDir);
+
+        // the call above returns an empty string if the user aborts the dialog
+        if (!newDir.isEmpty()) {
+            destinationDir = newDir;
+        }
+
+        // updating never is a bad idea
+        updateDestinationDirLabel();
+    }
+    
+private:
+    void updateDestinationDirLabel() {
+        QString text = destinationDir;
+
+        // fallback to default
+        if (text.isEmpty())
+            text = integratedAppImagesDestination().absolutePath() + " " + tr("(default)");
+
+        firstRunDialog->destinationDirLabel->setText(text);
+    }
+
+    void initUi() {
+        firstRunDialog = new Ui::FirstRunDialog;
+        // setupUi will modify this dialog so that it looks just like what we designed in Qt Designer
+        firstRunDialog->setupUi(this);
+
+        // set up logo in a QLabel
+        firstRunDialog->logoLabel->setText("");
+        auto pixmap = QPixmap::fromImage(QImage(":/AppImageLauncher.svg")).scaled(
+                firstRunDialog->logoLabel->size(),
+                Qt::KeepAspectRatio, Qt::SmoothTransformation
+        );
+        firstRunDialog->logoLabel->setPixmap(pixmap);
+
+        // setting icon in Qt Designer doesn't seem to work
+        firstRunDialog->customizeIntegrationDirButton->setIcon(this->style()->standardIcon(QStyle::SP_DirIcon));
+
+        // reset defaults
+        resetDefaults();
+
+        // set up all connections
+        connect(firstRunDialog->buttonBox, &QDialogButtonBox::clicked, this, &FirstRunDialog::handleButtonClicked);
+        connect(firstRunDialog->askMoveCheckBox, &QCheckBox::stateChanged, this, &FirstRunDialog::handleAskMoveCheckBoxStateChange);
+
+        connect(firstRunDialog->customizeIntegrationDirButton, &QPushButton::clicked, this, &FirstRunDialog::handleCustomizeIntegrationDirButtonClicked);
+
+        // 20 minutes of trial and error and the solution to make the window _really_ fixed size is sooo simple...
+        // another day, another thing learned about Qt's madnesses...
+        setFixedSize(width(), height());
+    }
+    
+public:
+    FirstRunDialog() {
+        initUi();
+    }
+
+    void writeConfigFile() {
+        bool askToMove = firstRunDialog->askMoveCheckBox->checkState() == Qt::Checked;
+        createConfigFile(askToMove ? 1 : 0, destinationDir, -1);
+    }
+};
+
+
+void showFirstRunDialog() {
+    auto dialog = new FirstRunDialog;
+
+    auto rv = dialog->exec();
+
+    if (rv <= 0) {
+        QApplication::exit(3);
+        exit(3);
+    }
+
+    dialog->writeConfigFile();
+
+    throw std::runtime_error("bla");
+}

--- a/src/ui/first-run.h
+++ b/src/ui/first-run.h
@@ -1,0 +1,1 @@
+void showFirstRunDialog();

--- a/src/ui/first-run.ui
+++ b/src/ui/first-run.ui
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FirstRunDialog</class>
+ <widget class="QDialog" name="FirstRunDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>531</width>
+    <height>293</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>First run</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>250</y>
+     <width>491</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
+   </property>
+   <property name="centerButtons">
+    <bool>false</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="welcomeTextLabel">
+   <property name="geometry">
+    <rect>
+     <x>160</x>
+     <y>20</y>
+     <width>361</width>
+     <height>141</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:11pt; font-weight:600;&quot;&gt;Welcome to AppImageLauncher!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;This little helper is designed to improve your AppImage experience on your computer.&lt;/p&gt;&lt;p&gt;It appears you have never run AppImageLauncher before. Please take a minute and configure your preferences. You can always change these later on, using the control panel.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="askMoveCheckBox">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>160</y>
+     <width>441</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Ask me whether to move new AppImages into a central location</string>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="logoLabel">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>121</width>
+     <height>121</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>TextLabel</string>
+   </property>
+  </widget>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>190</y>
+     <width>491</width>
+     <height>42</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="destDirVertLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
+    <item>
+     <widget class="QLabel" name="destinationDirDescLabel">
+      <property name="text">
+       <string>Integration target destination directory:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="destDirHorLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetFixedSize</enum>
+      </property>
+      <item>
+       <widget class="QLabel" name="destinationDirLabel">
+        <property name="font">
+         <font>
+          <family>DejaVu Sans Mono</family>
+         </font>
+        </property>
+        <property name="text">
+         <string>to be filled!</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="customizeIntegrationDirButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>15</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Customize</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FirstRunDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FirstRunDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "shared.h"
 #include "trashbin.h"
 #include "translationmanager.h"
+#include "first-run.h"
 
 // Runs an AppImage. Returns suitable exit code for main application.
 int runAppImage(const QString& pathToAppImage, unsigned long argc, char** argv) {
@@ -351,7 +352,7 @@ int main(int argc, char** argv) {
 
     // if config doesn't exist, create a default one
     if (config == nullptr) {
-        createDefaultConfigFile();
+        showFirstRunDialog();
     }
 
     // check for X-AppImage-Integrate=false

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -12,6 +12,7 @@ extern "C" {
 // library includes
 #include <QApplication>
 #include <QCommandLineParser>
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
@@ -353,6 +354,17 @@ int main(int argc, char** argv) {
     // if config doesn't exist, create a default one
     if (config == nullptr) {
         showFirstRunDialog();
+        config = getConfig();
+    }
+
+    if (config == nullptr) {
+        displayError("Could not read config file");
+    }
+
+    // if the user opted out of the "ask move" thing, we acn just run the AppImage
+    qDebug() << config->allKeys();
+    if (!config->contains("AppImageLauncher/ask_to_move") || !config->value("AppImageLauncher/ask_to_move").toBool()) {
+        return runAppImage(pathToAppImage, appImageArgv.size(), appImageArgv.data());
     }
 
     // check for X-AppImage-Integrate=false

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -333,7 +333,9 @@ int main(int argc, char** argv) {
 
     // enable and start/disable and stop appimagelauncherd service
     auto config = getConfig();
-    if (!config->contains("AppImageLauncher/enable_daemon") || config->value("AppImageLauncher/enable_daemon").toBool()) {
+
+    // assumes defaults if config doesn't exist or lacks the related key(s)
+    if (config == nullptr || !config->contains("AppImageLauncher/enable_daemon") || config->value("AppImageLauncher/enable_daemon").toBool()) {
         system("systemctl --user enable appimagelauncherd.service");
         system("systemctl --user start  appimagelauncherd.service");
     } else {
@@ -341,10 +343,15 @@ int main(int argc, char** argv) {
         system("systemctl --user stop    appimagelauncherd.service");
     }
 
-    // from now on, the code requires a UI
+    // beyond the next block, the code requires a UI
     // as we don't want to offer integration over a headless connection, we just run the AppImage
     if (isHeadless()) {
         return runAppImage(pathToAppImage, appImageArgv.size(), appImageArgv.data());
+    }
+
+    // if config doesn't exist, create a default one
+    if (config == nullptr) {
+        createDefaultConfigFile();
     }
 
     // check for X-AppImage-Integrate=false


### PR DESCRIPTION
This PR implements a first run dialog allowing users to customize AppImageLauncher's most important settings on first run (CC #153). It also implements a long-requested feature, disabling AIL's "nag screen" completely (closes #111).