### PR TITLE
AppImageLauncher Lite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     - env: DIST=bionic ARCH=i386
     - env: DIST=xenial ARCH=x86_64
     - env: DIST=xenial ARCH=i386
+    - env: DIST=xenial ARCH=x86_64 BUILD_LITE=1
+      name: AppImageLauncher Lite AppImage x86_64
+    - env: DIST=xenial ARCH=i386 BUILD_LITE=1
+      name: AppImageLauncher Lite AppImage i386
 
 script:
   - bash -ex travis/travis-docker.sh "$DIST"
@@ -20,7 +24,9 @@ after_success:
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
   - if [ "$TRAVIS_BRANCH" != "master" ] && [ "$TRAVIS_TAG" == "" ]; then export TRAVIS_EVENT_TYPE=pull_request; fi
   - |2
-    if [ "$DIST" == "xenial" ]; then
+    if [[ "$BUILD_LITE" != "" ]]; then
+        bash upload.sh appimagelauncher-lite-*.AppImage*
+    elif [[ "$DIST" == "xenial" ]]; then
         bash upload.sh appimagelauncher*.{deb,rpm}* appimagelauncher*.tar*
     else
         bash upload.sh appimagelauncher*.deb*

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -44,35 +44,49 @@ foreach(i libappimage libappimageupdate libappimageupdate-qt)
     endif()
 endforeach()
 
-# TODO: find alternative to the following "workaround" (a pretty dirty hack, actually...)
-# bundle update-binfmts as a fallback for distros which don't have it installed
-find_program(UPDATE_BINFMTS
-    NAMES update-binfmts
-    PATHS /usr/sbin
-)
-
-if(NOT UPDATE_BINFMTS STREQUAL UPDATE_BINFMTS-NOTFOUND AND EXISTS ${UPDATE_BINFMTS})
-    message(STATUS "Found update-binfmts, bundling: ${UPDATE_BINFMTS}")
-    install(
-        FILES /usr/sbin/update-binfmts
-        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-        DESTINATION ${_private_libdir} COMPONENT APPIMAGELAUNCHER
+if(NOT BUILD_LITE)
+    # TODO: find alternative to the following "workaround" (a pretty dirty hack, actually...)
+    # bundle update-binfmts as a fallback for distros which don't have it installed
+    find_program(UPDATE_BINFMTS
+        NAMES update-binfmts
+        PATHS /usr/sbin
     )
-else()
-    message(WARNING "update-binfmts could not be found. Please install the binfmt-support package if you intend to build RPM packages.")
-endif()
 
-# binfmt.d config file -- used as a fallback, if update-binfmts is not available
-configure_file(
-    ${PROJECT_SOURCE_DIR}/resources/binfmt.d/appimage.conf.in
-    ${PROJECT_BINARY_DIR}/resources/binfmt.d/appimage.conf
-    @ONLY
-)
-# caution: don't use ${CMAKE_INSTALL_LIBDIR} here, it's really just lib/binfmt.d
-install(
-    FILES ${PROJECT_BINARY_DIR}/resources/binfmt.d/appimage.conf
-    DESTINATION lib/binfmt.d COMPONENT APPIMAGELAUNCHER
-)
+    if(NOT UPDATE_BINFMTS STREQUAL UPDATE_BINFMTS-NOTFOUND AND EXISTS ${UPDATE_BINFMTS})
+        message(STATUS "Found update-binfmts, bundling: ${UPDATE_BINFMTS}")
+        install(
+            FILES /usr/sbin/update-binfmts
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+            DESTINATION ${_private_libdir} COMPONENT APPIMAGELAUNCHER
+        )
+    else()
+        message(WARNING "update-binfmts could not be found. Please install the binfmt-support package if you intend to build RPM packages.")
+    endif()
+
+    # binfmt.d config file -- used as a fallback, if update-binfmts is not available
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/resources/binfmt.d/appimage.conf.in
+        ${PROJECT_BINARY_DIR}/resources/binfmt.d/appimage.conf
+        @ONLY
+    )
+    # caution: don't use ${CMAKE_INSTALL_LIBDIR} here, it's really just lib/binfmt.d
+    install(
+        FILES ${PROJECT_BINARY_DIR}/resources/binfmt.d/appimage.conf
+        DESTINATION lib/binfmt.d COMPONENT APPIMAGELAUNCHER
+    )
+
+    # install systemd service configuration for appimagelauncherfs
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/resources/appimagelauncherfs.service.in
+        ${PROJECT_BINARY_DIR}/resources/appimagelauncherfs.service
+        @ONLY
+    )
+    # caution: don't use ${CMAKE_INSTALL_LIBDIR} here, it's really just lib/systemd/user
+    install(
+        FILES ${PROJECT_BINARY_DIR}/resources/appimagelauncherfs.service
+        DESTINATION lib/systemd/user/ COMPONENT APPIMAGELAUNCHERFS
+    )
+endif()
 
 # install systemd service configuration for appimagelauncherd
 configure_file(
@@ -84,16 +98,4 @@ configure_file(
 install(
     FILES ${PROJECT_BINARY_DIR}/resources/appimagelauncherd.service
     DESTINATION lib/systemd/user/ COMPONENT APPIMAGELAUNCHER
-)
-
-# install systemd service configuration for appimagelauncherfs
-configure_file(
-    ${PROJECT_SOURCE_DIR}/resources/appimagelauncherfs.service.in
-    ${PROJECT_BINARY_DIR}/resources/appimagelauncherfs.service
-    @ONLY
-)
-# caution: don't use ${CMAKE_INSTALL_LIBDIR} here, it's really just lib/systemd/user
-install(
-    FILES ${PROJECT_BINARY_DIR}/resources/appimagelauncherfs.service
-    DESTINATION lib/systemd/user/ COMPONENT APPIMAGELAUNCHERFS
 )

--- a/resources/appimagelauncher-lite-AppRun.sh
+++ b/resources/appimagelauncher-lite-AppRun.sh
@@ -1,0 +1,165 @@
+#! /bin/bash
+
+set -e
+
+if [[ "$VERBOSE" != "" ]]; then
+    set -x
+fi
+
+# shift does not work if no arguments have been passed, therefore we just handle that situation right now
+if [[ "$1" == "" ]]; then
+    echo "Usage: ${APPIMAGE:-$0} <operation> [...]" 1>&2
+    exit 2
+fi
+
+firstarg="$1"
+shift
+
+
+prefix="appimagelauncher-lite"
+install_dir=~/.local/lib/appimagelauncher-lite
+installed_appimage_path="$install_dir"/appimagelauncher-lite.AppImage
+settings_desktop_file_path=~/.local/share/applications/"$prefix"-AppImageLauncherSettings.desktop
+systemd_user_units_dir=~/.config/systemd/user/
+appimagelauncherd_systemd_service_name=appimagelauncherd.service
+integrated_icon_path=~/.local/share/icons/hicolor/scalable/apps/AppImageLauncher-Lite.svg
+
+test_globally_installed() {
+    which AppImageLauncher &>/dev/null && return 0
+    type AppImageLauncher &>/dev/null && return 0
+    [[ -d /usr/lib/*/appimagelauncher ]] && return 0
+
+    return 1
+}
+
+test_installed_already() {
+    [[ -d "$install_dir" ]] && return 0
+
+    return 1
+}
+
+ail_lite_notify_desktop_integration() {
+    update-desktop-database ~/.local/share/applications
+    gtk-update-icon-cache
+}
+
+ail_lite_install() {
+    if [[ "$APPIMAGE" == "" ]]; then
+        echo "Error: not running from AppImage, aborting"
+        return 2
+    fi
+
+    # create default Applications directory
+    mkdir -p ~/Applications
+
+    # prepare install dir
+    mkdir -p "$install_dir"
+    mkdir -p "$install_dir"/systemd
+
+    # copy ourselves to install dir
+    cp "$APPIMAGE" "$installed_appimage_path"
+
+    # set up appimagelauncherd
+    cat > "$install_dir"/systemd/"$appimagelauncherd_systemd_service_name" <<EOF
+[Unit]
+Description=AppImageLauncher daemon
+
+[Service]
+ExecStart=${installed_appimage_path} appimagelauncherd
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+    # now we need to make systemd aware of your service file
+    ln -s "$install_dir"/systemd/"$appimagelauncherd_systemd_service_name" "$systemd_user_units_dir"/
+
+    systemctl --user daemon-reload
+    systemctl --user enable "$appimagelauncherd_systemd_service_name"
+    systemctl --user start "$appimagelauncherd_systemd_service_name"
+
+    # set up desktop file for AppImageLauncherSettings
+    cat > ~/.local/share/applications/appimagelauncher-lite-AppImageLauncherSettings.desktop <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=${installed_appimage_path} AppImageLauncherSettings %f
+Name=AppImageLauncher Settings
+Icon=AppImageLauncher-Lite
+Terminal=false
+Categories=Utility;
+X-AppImage-Integrate=false
+StartupWMClass=AppImageLauncherSettings
+EOF
+
+    # copy icon for AppImageLauncherSettings
+    # TODO: copy PNG icons, too
+    install "$APPDIR"/usr/share/icons/hicolor/scalable/apps/AppImageLauncher.svg "$integrated_icon_path"
+
+    # notify desktop of changes
+    ail_lite_notify_desktop_integration
+
+    echo "AppImageLauncher Lite has been installed successfully."
+    return 0
+}
+
+ail_lite_uninstall() {
+    # remove appimagelauncherd systemd stuff
+    systemctl --user stop "$appimagelauncherd_systemd_service_name"
+    systemctl --user disable "$appimagelauncherd_systemd_service_name"
+    systemctl --user daemon-reload
+
+    # remove all the installed files
+    rm -r "$install_dir"
+
+    echo "AppImageLauncher Lite has been uninstalled successfully."
+    return 0
+}
+
+# ensure this important variable is available, as most operations (except for install) can be done without being run
+# from via AppImage runtime (e.g., while the AppImage is extracted, which is great for testing)
+export APPDIR=${APPDIR:-$(readlink -f $(dirname "$0"))}
+
+case "$firstarg" in
+    appimagelauncherd|AppImageLauncherSettings)
+        exec "$APPDIR"/usr/bin/"$firstarg" "$@"
+        ;;
+    cli|ail-cli)
+        exec "$APPDIR"/usr/bin/ail-cli "$@"
+        ;;
+    remove|update)
+        exec "$APPDIR"/usr/lib/**/appimagelauncher/"$firstarg" "$@"
+        ;;
+    install)
+        if test_globally_installed; then
+            echo "Error: AppImageLauncher is installed system-wide already, not installing on top" 1>&2
+            exit 2
+        fi
+
+        if test_installed_already; then
+            echo "Error: AppImageLauncher Lite is installed already, please uninstall before trying to reinstall" 1>&2
+            exit 2
+        fi
+
+        echo "Installing AppImageLauncher Lite"
+        ail_lite_install
+        ;;
+    uninstall)
+        if ! test_installed_already; then
+            echo "Error: AppImageLauncher Lite does not seem to be installed" 1>&2
+            exit 2
+        fi
+
+        echo "Uninstalling AppImageLauncher Lite"
+        ail_lite_uninstall
+        ;;
+    *)
+        echo "Unknown operation: $firstarg";
+        exit 2
+        ;;
+esac
+
+
+

--- a/resources/appimagelauncher-lite-AppRun.sh
+++ b/resources/appimagelauncher-lite-AppRun.sh
@@ -8,7 +8,7 @@ fi
 
 # shift does not work if no arguments have been passed, therefore we just handle that situation right now
 if [[ "$1" == "" ]]; then
-    echo "Usage: ${APPIMAGE:-$0} <operation> [...]" 1>&2
+    echo "Error: no option passed, use --help for more information"
     exit 2
 fi
 
@@ -118,11 +118,31 @@ ail_lite_uninstall() {
     return 0
 }
 
+print_help() {
+    echo "Usage: $0 <option> ..."
+    echo
+    echo "Main options:"
+    echo "  install       Install AppImageLauncher into your user account"
+    echo "  uninstall     Uninstall AppImageLauncher from your user account"
+    echo "  help|--help   Display this help"
+    echo
+    echo "Other options (mainly for use by AppImageLauncher Lite internally):"
+    echo "  appimagelauncherd          Run appimagelauncherd"
+    echo "  AppImageLauncherSettings   Display AppImageLauncher Lite configuration utility"
+    echo "  cli [or ali-cli]           Run AppImageLauncher cli (use \"cli --help\" for more information)"
+    echo "  remove <path>              Run removal helper to remove AppImage <path>"
+    echo "  update <path>              Run update helper to update AppImage <path>"
+}
+
 # ensure this important variable is available, as most operations (except for install) can be done without being run
 # from via AppImage runtime (e.g., while the AppImage is extracted, which is great for testing)
 export APPDIR=${APPDIR:-$(readlink -f $(dirname "$0"))}
 
 case "$firstarg" in
+    help|--help)
+        print_help
+        exit 0
+        ;;
     appimagelauncherd|AppImageLauncherSettings)
         exec "$APPDIR"/usr/bin/"$firstarg" "$@"
         ;;

--- a/resources/appimagelauncher-lite.desktop
+++ b/resources/appimagelauncher-lite.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=appimagelauncher-lite
+Exec=appimagelauncher-lite
+Icon=AppImageLauncher
+Type=Application
+X-AppImage-Integrate=false
+NoDisplay=true
+Categories=Utility;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 
 add_compile_options(-Wall -Wpedantic)
 
+if(BUILD_LITE)
+    add_definitions(-DBUILD_LITE)
+endif()
+
 # utility libraries
 add_subdirectory(fswatcher)
 add_subdirectory(i18n)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,9 @@ add_subdirectory(daemon)
 add_subdirectory(ui)
 
 # FUSE filesystem AppImageLauncherFS
-add_subdirectory(fusefs)
+if(NOT BUILD_LITE)
+    add_subdirectory(fusefs)
+endif()
 
 # CLI helper allowing other tools to utilize AppImageLauncher's code for e.g., integrating AppImages
 add_subdirectory(cli)

--- a/src/cli/cli_main.cpp
+++ b/src/cli/cli_main.cpp
@@ -1,3 +1,6 @@
+// system headers
+#include <sstream>
+
 // library headers
 #include <QCoreApplication>
 #include <QCommandLineParser>
@@ -16,11 +19,18 @@ int main(int argc, char** argv) {
 
     QCoreApplication app(argc, argv);
 
+    std::ostringstream version;
+    version << "version " << APPIMAGELAUNCHER_VERSION << " "
+            << "(git commit " << APPIMAGELAUNCHER_GIT_COMMIT << "), built on "
+            << APPIMAGELAUNCHER_BUILD_DATE;
+    QCoreApplication::setApplicationVersion(QString::fromStdString(version.str()));
+
     QCommandLineParser parser;
 
     parser.addPositionalArgument("<command>", "Command to run (see help for more information");
     parser.addPositionalArgument("[...]", "command-specific additional arguments");
     parser.addHelpOption();
+    parser.addVersionOption();
 
     parser.process(app);
 

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -493,6 +493,7 @@ bool installDesktopFileAndIcons(const QString& pathToAppImage, bool resolveColli
     }
 #endif
 
+#ifndef BUILD_LITE
     // PRIVATE_LIBDIR will be a relative path most likely
     // therefore, we need to detect the install prefix based on our own binary path, and then calculate the path to
     // the helper tools based on that
@@ -508,15 +509,28 @@ bool installDesktopFileAndIcons(const QString& pathToAppImage, bool resolveColli
         privateLibDirPath = ownBinaryDirPath + "/../ui";
     }
 
+    const char helperIconName[] = "AppImageLauncher";
+#else
+    const char helperIconName[] = "AppImageLauncher-Lite";
+#endif
+
     // add Remove action
     {
         const auto removeSectionName = "Desktop Action Remove";
 
         g_key_file_set_string(desktopFile.get(), removeSectionName, "Name", "Remove AppImage from system");
-        g_key_file_set_string(desktopFile.get(), removeSectionName, "Icon", "AppImageLauncher");
+        g_key_file_set_string(desktopFile.get(), removeSectionName, "Icon", helperIconName);
 
         std::ostringstream removeExecPath;
-        removeExecPath << privateLibDirPath.toStdString() << "/remove" << " \"" << pathToAppImage.toStdString() << "\"";
+
+#ifndef BUILD_LITE
+        removeExecPath << privateLibDirPath.toStdString() << "/remove";
+#else
+        removeExecPath << getenv("HOME") << "/.local/lib/appimagelauncher-lite/appimagelauncher-lite.AppImage remove";
+#endif
+
+        removeExecPath << " \"" << pathToAppImage.toStdString() << "\"";
+
         g_key_file_set_string(desktopFile.get(), removeSectionName, "Exec", removeExecPath.str().c_str());
 
         // install translations
@@ -540,10 +554,17 @@ bool installDesktopFileAndIcons(const QString& pathToAppImage, bool resolveColli
             const auto updateSectionName = "Desktop Action Update";
 
             g_key_file_set_string(desktopFile.get(), updateSectionName, "Name", "Update AppImage");
-            g_key_file_set_string(desktopFile.get(), updateSectionName, "Icon", "AppImageLauncher");
+            g_key_file_set_string(desktopFile.get(), updateSectionName, "Icon", helperIconName);
 
             std::ostringstream updateExecPath;
-            updateExecPath << privateLibDirPath.toStdString() << "/update" << " \"" << pathToAppImage.toStdString() << "\"";;
+
+#ifndef BUILD_LITE
+            updateExecPath << privateLibDirPath.toStdString() << "/update";
+#else
+            updateExecPath << getenv("HOME") << "/.local/lib/appimagelauncher-lite/appimagelauncher-lite.AppImage update";
+#endif
+            updateExecPath << " \"" << pathToAppImage.toStdString() << "\"";
+
             g_key_file_set_string(desktopFile.get(), updateSectionName, "Exec", updateExecPath.str().c_str());
 
             // install translations

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,18 +1,20 @@
-# main AppImageLauncher application
-add_executable(AppImageLauncher main.cpp resources.qrc first-run.cpp first-run.h first-run.ui)
-target_link_libraries(AppImageLauncher shared PkgConfig::glib libappimage shared)
+if(NOT BUILD_LITE)
+    # main AppImageLauncher application
+    add_executable(AppImageLauncher main.cpp resources.qrc first-run.cpp first-run.h first-run.ui)
+    target_link_libraries(AppImageLauncher shared PkgConfig::glib libappimage shared)
 
-# set binary runtime rpath to make sure the libappimage.so built and installed by this project is going to be used
-# by the installed binaries (be it the .deb, the AppImage, or whatever)
-# in order to make the whole install tree relocatable, a relative path is used
-set_target_properties(AppImageLauncher PROPERTIES INSTALL_RPATH ${_rpath})
+    # set binary runtime rpath to make sure the libappimage.so built and installed by this project is going to be used
+    # by the installed binaries (be it the .deb, the AppImage, or whatever)
+    # in order to make the whole install tree relocatable, a relative path is used
+    set_target_properties(AppImageLauncher PROPERTIES INSTALL_RPATH ${_rpath})
 
-install(
-    TARGETS
-    AppImageLauncher
-    RUNTIME DESTINATION ${_bindir} COMPONENT APPIMAGELAUNCHER
-    LIBRARY DESTINATION ${_libdir} COMPONENT APPIMAGELAUNCHER
-)
+    install(
+        TARGETS
+        AppImageLauncher
+        RUNTIME DESTINATION ${_bindir} COMPONENT APPIMAGELAUNCHER
+        LIBRARY DESTINATION ${_libdir} COMPONENT APPIMAGELAUNCHER
+    )
+endif()
 
 # AppImageLauncherSettings application
 add_executable(AppImageLauncherSettings settings_main.cpp settings_dialog.ui settings_dialog.cpp)

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -13,6 +13,15 @@ SettingsDialog::SettingsDialog(QWidget* parent) :
 
     loadSettings();
 
+// cosmetic changes in lite mode
+#ifndef BUILD_LITE
+    ui->checkBoxEnableDaemon->setChecked(true);
+    ui->checkBoxEnableDaemon->setEnabled(false);
+
+    ui->checkBoxAskMove->setChecked(false);
+    ui->checkBoxAskMove->setEnabled(false);
+#endif
+
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &SettingsDialog::onDialogAccepted);
     connect(ui->toolButtonChooseAppsDir, &QToolButton::released, this, &SettingsDialog::onChooseAppsDirClicked);
 
@@ -22,6 +31,12 @@ SettingsDialog::SettingsDialog(QWidget* parent) :
     availableFeatures << "<span style='color: green;'>✔</span> " + tr("updater available for AppImages supporting AppImageUpdate");
 #else
     availableFeatures << "<span style='color: red;'>🞬</span> " + tr("updater unavailable");
+#endif
+
+#ifndef BUILD_LITE
+    availableFeatures << "<br /><br />"
+                      << tr("<strong>Note: this is an AppImageLauncher Lite build, only supports a limited set of features</strong><br />"
+                            "Please install the full version via the provided native packages to enjoy the full AppImageLauncher experience");
 #endif
 
     ui->featuresLabel->setText(availableFeatures.join('\n'));

--- a/src/ui/settings_dialog.ui
+++ b/src/ui/settings_dialog.ui
@@ -76,6 +76,12 @@
    </item>
    <item>
     <widget class="QGroupBox" name="groupBoxAvailableFeatures">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="locale">
       <locale language="English" country="UnitedStates"/>
      </property>
@@ -88,8 +94,20 @@
         <x>10</x>
         <y>30</y>
         <width>431</width>
-        <height>41</height>
+        <height>430</height>
        </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>430</height>
+       </size>
       </property>
       <property name="layoutDirection">
        <enum>Qt::LeftToRight</enum>
@@ -99,6 +117,9 @@
       </property>
       <property name="alignment">
        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </widget>

--- a/travis/Dockerfile.build-bionic-i386-cross
+++ b/travis/Dockerfile.build-bionic-i386-cross
@@ -45,4 +45,5 @@ RUN dpkg --add-architecture i386 && \
         qttools5-dev-tools:i386 \
         qt5-qmake-bin:i386 \
         libarchive-dev:i386 \
-        libboost-filesystem-dev:i386
+        libboost-filesystem-dev:i386 \
+        zlib1g:i386

--- a/travis/Dockerfile.build-cosmic-i386-cross
+++ b/travis/Dockerfile.build-cosmic-i386-cross
@@ -45,4 +45,5 @@ RUN dpkg --add-architecture i386 && \
         qttools5-dev-tools:i386 \
         qt5-qmake-bin:i386 \
         libarchive-dev:i386 \
-        libboost-filesystem-dev:i386
+        libboost-filesystem-dev:i386 \
+        zlib1g:i386

--- a/travis/Dockerfile.build-xenial-i386-cross
+++ b/travis/Dockerfile.build-xenial-i386-cross
@@ -46,4 +46,5 @@ RUN dpkg --add-architecture i386 && \
         libfontconfig1-dev:i386 \
         libfreetype6-dev:i386 \
         libarchive-dev:i386 \
-        libboost-filesystem-dev:i386
+        libboost-filesystem-dev:i386 \
+        zlib1g:i386

--- a/travis/build-lite.sh
+++ b/travis/build-lite.sh
@@ -72,7 +72,7 @@ wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/cont
 chmod -v +x linuxdeploy*-"$ARCH".AppImage
 
 export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
-export VERSION=$(src/cli/ail-cli --version)
+export VERSION=$(src/cli/ail-cli --version | awk '{print $3}')
 export APPIMAGE_EXTRACT_AND_RUN=1
 
 ./linuxdeploy-"$ARCH".AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop

--- a/travis/build-lite.sh
+++ b/travis/build-lite.sh
@@ -71,8 +71,8 @@ wget https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/downloa
 wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-"$ARCH".AppImage
 chmod -v +x linuxdeploy*-"$ARCH".AppImage
 
-export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
 export VERSION=$(src/cli/ail-cli --version | awk '{print $3}')
+export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
 export APPIMAGE_EXTRACT_AND_RUN=1
 
 ./linuxdeploy-"$ARCH".AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop

--- a/travis/build-lite.sh
+++ b/travis/build-lite.sh
@@ -75,6 +75,6 @@ export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
 export VERSION=$(src/cli/ail-cli --version)
 export APPIMAGE_EXTRACT_AND_RUN=1
 
-./linuxdeploy-x86_64.AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop
+./linuxdeploy-"$ARCH".AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop
 
 mv "$OUTPUT" "$OLD_CWD"

--- a/travis/build-lite.sh
+++ b/travis/build-lite.sh
@@ -1,0 +1,79 @@
+#! /bin/bash
+
+if [ "$ARCH" == "" ]; then
+    echo "Error: you must set \$ARCH"
+    exit 2
+fi
+
+set -x
+set -e
+
+# use RAM disk if possible
+if [ "$CI" == "" ] && [ -d /dev/shm ]; then
+    TEMP_BASE=/dev/shm
+else
+    TEMP_BASE=/tmp
+fi
+
+BUILD_DIR=$(mktemp -d -p "$TEMP_BASE" AppImageLauncher-build-XXXXXX)
+
+cleanup () {
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+    fi
+}
+
+trap cleanup EXIT
+
+# store repo root as variable
+REPO_ROOT=$(readlink -f $(dirname "${BASH_SOURCE[0]}")/..)
+OLD_CWD=$(readlink -f .)
+
+pushd "$BUILD_DIR"
+
+# install more recent CMake version which fixes some linking issue in CMake < 3.10
+# Fixes https://github.com/TheAssassin/AppImageLauncher/issues/106
+# Upstream bug: https://gitlab.kitware.com/cmake/cmake/issues/17389
+wget https://cmake.org/files/v3.13/cmake-3.13.2-Linux-x86_64.tar.gz -qO- | tar xz --strip-components=1
+export PATH=$(readlink -f bin/):"$PATH"
+which cmake
+cmake --version
+
+EXTRA_CMAKE_FLAGS=
+
+if [ "$ARCH" == "i386" ]; then
+    EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$REPO_ROOT/cmake/toolchains/i386-linux-gnu.cmake -DUSE_SYSTEM_XZ=ON -DUSE_SYSTEM_LIBARCHIVE=ON"
+    # TODO check if this can be removed
+    if [ "$DEBIAN_DIST" != "bionic" ] && [ "$DEBIAN_DIST" != "cosmic" ]; then
+        export QT_SELECT=qt5-i386-linux-gnu
+    else
+        export QT_SELECT=qt5
+    fi
+fi
+
+cmake "$REPO_ROOT" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo $EXTRA_CMAKE_FLAGS -DTRAVIS_BUILD=ON -DBUILD_TESTING=OFF -DBUILD_LITE=ON
+
+# compile dependencies
+make -j $(nproc) libappimage libappimageupdate libappimageupdate-qt
+
+# re-run cmake to update paths to dependencies
+cmake .
+
+# build rest
+make -j $(nproc)
+
+# prepare AppDir
+make install DESTDIR=AppDir
+
+# build AppImage
+wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-"$ARCH".AppImage
+wget https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-"$ARCH".AppImage
+wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-"$ARCH".AppImage
+chmod -v +x linuxdeploy*-"$ARCH".AppImage
+
+export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
+export VERSION=$(src/cli/ail-cli --version)
+
+./linuxdeploy-x86_64.AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop
+
+mv "$OUTPUT" "$OLD_CWD"

--- a/travis/build-lite.sh
+++ b/travis/build-lite.sh
@@ -73,6 +73,7 @@ chmod -v +x linuxdeploy*-"$ARCH".AppImage
 
 export OUTPUT=appimagelauncher-lite-"$VERSION"-"$ARCH".AppImage
 export VERSION=$(src/cli/ail-cli --version)
+export APPIMAGE_EXTRACT_AND_RUN=1
 
 ./linuxdeploy-x86_64.AppImage --plugin qt --appdir $(readlink -f AppDir) --custom-apprun "$REPO_ROOT"/resources/appimagelauncher-lite-AppRun.sh --output appimage -d "$REPO_ROOT"/resources/appimagelauncher-lite.desktop
 

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -52,7 +52,7 @@ fi
 cmake "$REPO_ROOT" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo $EXTRA_CMAKE_FLAGS -DTRAVIS_BUILD=ON -DBUILD_TESTING=OFF
 
 # now, compile
-make
+make -j $(nproc)
 
 # re-run cmake to find built shared objects with the globs, and update the CPack files
 cmake .

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -42,7 +42,7 @@ fi
 
 if [ "$ARCH" == "i386" ]; then
     EXTRA_CMAKE_FLAGS="$EXTRA_CMAKE_FLAGS -DCMAKE_TOOLCHAIN_FILE=$REPO_ROOT/cmake/toolchains/i386-linux-gnu.cmake -DUSE_SYSTEM_XZ=ON -DUSE_SYSTEM_LIBARCHIVE=ON"
-    if [ "$BIONIC" == "" ] && [ "$COSMIC" == "" ]; then
+    if [ "$DEBIAN_DIST" != "bionic" ] && [ "$DEBIAN_DIST" != "cosmic" ]; then
         export QT_SELECT=qt5-i386-linux-gnu
     else
         export QT_SELECT=qt5

--- a/travis/travis-docker.sh
+++ b/travis/travis-docker.sh
@@ -27,5 +27,11 @@ fi
 
 docker build -t "$IMAGE" -f "$DOCKERFILE" .
 
+if [[ "$BUILD_LITE" == "" ]]; then
+    build_script=travis-build.sh
+else
+    build_script=build-lite.sh
+fi
+
 docker run -e ARCH -e TRAVIS_BUILD_NUMBER --rm -it -v $(readlink -f ..):/ws "$IMAGE" \
-    bash -xc "export CI=1 && export DEBIAN_DIST=\"$DOCKER_DIST\" && cd /ws && source travis/travis-build.sh"
+    bash -xc "export CI=1 && export DEBIAN_DIST=\"$DOCKER_DIST\" && cd /ws && source travis/$build_script"


### PR DESCRIPTION
AppImageLauncher Lite is an alternative way to install AppImageLauncher. It's a no-root-required version that is shipped as an AppImage and can be installed from the CLI.

**NOTE: The recommended and most powerful installation method is still to use the native packages!** This is just an alternative for people who can't afford using `sudo`. It lacks many useful features.

I selected the most useful features of AppImageLauncher that can be installed and managed without access to root:
- appimagelauncherd (automatically integrate AppImages in `~/Applications` (or any other dir you choose for your apps)
- remove and update helper (manage and update your AppImages from your app launcher via context menu)
- AppImageLauncherSettings (configure AppImageLauncher from a UI instead of having to edit the config file)
- ail-cli (might be useful for people who wish to automate some processes e.g., in scripts)

You can install the AppImage by calling it via CLI with `install` (and remove it with `uninstall`).

TODO:
- put proper version number in AppImage filename (CC #177)
- test in real world systems

@probonopd @azubieta please test, AppImage available e.g., [here](https://artifacts.assassinate-you.net/artifactory/AppImageLauncher/travis-623/appimagelauncher-lite-1.3.1-x86_64.AppImage).

Fixes #161.