### PR TITLE
Only the ON_CLOSE and ON_MOVE events are required to call integrate

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -74,8 +74,8 @@ int main(int argc, char* argv[]) {
     worker.moveToThread(&workerThread);
     workerThread.start();
 
-    FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileCreated, &worker, &Worker::scheduleForIntegration);
-    FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileDeleted, &worker, &Worker::scheduleForUnintegration);
+    FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileChanged, &worker, &Worker::scheduleForIntegration);
+    FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileRemoved, &worker, &Worker::scheduleForUnintegration);
 
     if (!watcher.startWatching()) {
         std::cerr << "Could not start watching directories" << std::endl;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -75,7 +75,6 @@ int main(int argc, char* argv[]) {
     workerThread.start();
 
     FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileCreated, &worker, &Worker::scheduleForIntegration);
-    FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileModified, &worker, &Worker::scheduleForIntegration);
     FileSystemWatcher::connect(&watcher, &FileSystemWatcher::fileDeleted, &worker, &Worker::scheduleForUnintegration);
 
     if (!watcher.startWatching()) {

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -24,8 +24,10 @@ public:
 class FileSystemWatcher::PrivateData {
 public:
     enum EVENT_TYPES {
+        // events that indicate file creations, modifications etc.
         fileChangeEvents = IN_CLOSE_WRITE | IN_MOVE,
-        fileDeletionEvents = IN_DELETE | IN_MOVED_FROM,
+        // events that indicate a file removal from a directory, e.g., deletion or moving to another location
+        fileRemovedEvents = IN_DELETE | IN_MOVED_FROM,
     };
 
 public:
@@ -88,7 +90,7 @@ public:
     };
 
     bool startWatching() {
-        static const auto mask = fileChangeEvents | fileDeletionEvents;
+        static const auto mask = fileCreationEvents | fileDeletionEvents;
 
         for (const auto& directory : watchedDirectories) {
             const int watchFd = inotify_add_watch(fd, directory.toStdString().c_str(), mask);
@@ -162,7 +164,7 @@ void FileSystemWatcher::readEventsForever() {
             const auto mask = event.mask;
             if (mask & d->fileChangeEvents) {
                 emit fileCreated(event.path);
-            } else if (mask & d->fileDeletionEvents) {
+            } else if (mask & d->fileRemovedEvents) {
                 emit fileDeleted(event.path);
             }
         }

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -163,9 +163,9 @@ void FileSystemWatcher::readEventsForever() {
         for (const auto& event : events) {
             const auto mask = event.mask;
             if (mask & d->fileChangeEvents) {
-                emit fileCreated(event.path);
+                emit fileChanged(event.path);
             } else if (mask & d->fileRemovedEvents) {
-                emit fileDeleted(event.path);
+                emit fileRemoved(event.path);
             }
         }
     }

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -24,7 +24,7 @@ public:
 class FileSystemWatcher::PrivateData {
 public:
     enum EVENT_TYPES {
-        fileCreationEvents = IN_CLOSE_WRITE | IN_MOVE,
+        fileChangeEvents = IN_CLOSE_WRITE | IN_MOVE,
         fileDeletionEvents = IN_DELETE | IN_MOVED_FROM,
     };
 
@@ -88,7 +88,7 @@ public:
     };
 
     bool startWatching() {
-        static const auto mask = fileCreationEvents | fileDeletionEvents;
+        static const auto mask = fileChangeEvents | fileDeletionEvents;
 
         for (const auto& directory : watchedDirectories) {
             const int watchFd = inotify_add_watch(fd, directory.toStdString().c_str(), mask);
@@ -160,7 +160,7 @@ void FileSystemWatcher::readEventsForever() {
 
         for (const auto& event : events) {
             const auto mask = event.mask;
-            if (mask & d->fileCreationEvents) {
+            if (mask & d->fileChangeEvents) {
                 emit fileCreated(event.path);
             } else if (mask & d->fileDeletionEvents) {
                 emit fileDeleted(event.path);

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -27,7 +27,7 @@ public:
         // events that indicate file creations, modifications etc.
         fileChangeEvents = IN_CLOSE_WRITE | IN_MOVE,
         // events that indicate a file removal from a directory, e.g., deletion or moving to another location
-        fileRemovedEvents = IN_DELETE | IN_MOVED_FROM,
+        fileRemovalEvents = IN_DELETE | IN_MOVED_FROM,
     };
 
 public:
@@ -90,7 +90,7 @@ public:
     };
 
     bool startWatching() {
-        static const auto mask = fileCreationEvents | fileDeletionEvents;
+        static const auto mask = fileChangeEvents | fileRemovalEvents;
 
         for (const auto& directory : watchedDirectories) {
             const int watchFd = inotify_add_watch(fd, directory.toStdString().c_str(), mask);

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -24,8 +24,7 @@ public:
 class FileSystemWatcher::PrivateData {
 public:
     enum EVENT_TYPES {
-        fileCreationEvents = IN_CREATE | IN_MOVED_TO,
-        fileModificationEvents = IN_CLOSE_WRITE | IN_MODIFY,
+        fileCreationEvents = IN_CLOSE_WRITE | IN_MOVE,
         fileDeletionEvents = IN_DELETE | IN_MOVED_FROM,
     };
 
@@ -89,7 +88,7 @@ public:
     };
 
     bool startWatching() {
-        static const auto mask = fileCreationEvents | fileModificationEvents | fileDeletionEvents;
+        static const auto mask = fileCreationEvents | fileDeletionEvents;
 
         for (const auto& directory : watchedDirectories) {
             const int watchFd = inotify_add_watch(fd, directory.toStdString().c_str(), mask);
@@ -165,8 +164,6 @@ void FileSystemWatcher::readEventsForever() {
                 emit fileCreated(event.path);
             } else if (mask & d->fileDeletionEvents) {
                 emit fileDeleted(event.path);
-            } else if (mask & d->fileModificationEvents) {
-                emit fileModified(event.path);
             }
         }
     }

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -164,7 +164,7 @@ void FileSystemWatcher::readEventsForever() {
             const auto mask = event.mask;
             if (mask & d->fileChangeEvents) {
                 emit fileChanged(event.path);
-            } else if (mask & d->fileRemovedEvents) {
+            } else if (mask & d->fileRemovalEvents) {
                 emit fileRemoved(event.path);
             }
         }

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -37,6 +37,5 @@ public:
 
 signals:
     void fileCreated(QString path);
-    void fileModified(QString path);
     void fileDeleted(QString path);
 };

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -36,6 +36,6 @@ public:
     QStringList directories();
 
 signals:
-    void fileCreated(QString path);
-    void fileDeleted(QString path);
+    void fileChanged(QString path);
+    void fileRemoved(QString path);
 };


### PR DESCRIPTION
The close event after a write operation is the one that give us a hint about a file download or copy operation finished. Therefore that's the only we should care about. The created or modified events only produce noise in this scenario.
 
fix #176 
