### PR TITLE
Use xenial for xenial builds, as intended

### DIFF
--- a/travis/Dockerfile.build-xenial
+++ b/travis/Dockerfile.build-xenial
@@ -1,7 +1,7 @@
 # used to cache installed dependencies for bionic builds
 # this speeds up builds during development, as the dependencies are just installed _once_
 
-FROM ubuntu:bionic
+FROM ubuntu:xenial
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install qt5-default \


### PR DESCRIPTION
Seems like this was broken since ~ June.

Fixes #191.