### PR TITLE
Watch additional directories

### DIFF
--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -25,6 +25,7 @@ extern "C" {
 #include <QMessageBox>
 #include <QObject>
 #include <QRegularExpression>
+#include <QSet>
 #include <QSettings>
 #include <QStandardPaths>
 #ifdef ENABLE_UPDATE_HELPER
@@ -235,6 +236,10 @@ QDir integratedAppImagesDestination() {
         return config->value(keyName).toString();
 
     return DEFAULT_INTEGRATION_DESTINATION;
+}
+
+QSet<QString> additionalAppImagesLocations() {
+    return QSet<QString>{} << "/Applications";
 }
 
 QString buildPathToIntegratedAppImage(const QString& pathToAppImage) {

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -65,6 +65,10 @@ std::shared_ptr<QSettings> getConfig();
 // return directory into which the integrated AppImages will be moved
 QDir integratedAppImagesDestination();
 
+// additional directories to monitor for AppImages, and to permit AppImages to be within (i.e., shall not ask whether
+// to move to the main location, if they're in one of these, it's all good)
+QSet<QString> additionalAppImagesLocations();
+
 // build path to standard location for integrated AppImages
 QString buildPathToIntegratedAppImage(const QString& pathToAppImage);
 

--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -424,7 +424,19 @@ int main(int argc, char** argv) {
             return runAppImage(pathToAppImage, appImageArgv.size(), appImageArgv.data());
         };
 
-        if (!isInDirectory(pathToAppImage, integratedAppImagesDestination().path())) {
+        bool needToAskAboutMoving = !isInDirectory(pathToAppImage, integratedAppImagesDestination().path());
+
+        // not so fast: even if it's not in the main integration directory, there's more viable locations where
+        // AppImages may reside just fine
+        if (needToAskAboutMoving) {
+            for (const auto& additionalLocation : additionalAppImagesLocations()) {
+                if (isInDirectory(pathToAppImage, additionalLocation)) {
+                    needToAskAboutMoving = false;
+                }
+            }
+        }
+
+        if (needToAskAboutMoving) {
             auto* messageBox = new QMessageBox(
                 QMessageBox::Warning,
                 QMessageBox::tr("Warning"),
@@ -445,7 +457,7 @@ int main(int argc, char** argv) {
             messageBox->setDefaultButton(QMessageBox::Yes);
             messageBox->show();
 
-             QApplication::exec();
+            QApplication::exec();
 
             // if the user selects No, then continue as if the AppImage would not be in this directory
             if (messageBox->clickedButton() == messageBox->button(QMessageBox::Yes)) {


### PR DESCRIPTION
This PR creates the foundations to implement #135 and #154. It essentially defines a mechanism for AppImageLauncher that deals with the need of having additional locations containing AppImages aside from the central integration directory within the users' homes.

As a first step, we now support a directory `/Applications` the system root directory.

Closes #135.