### PR TITLE
Monitor mounted filesystems

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -14,5 +14,10 @@
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="ObjectiveC">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
   </code_scheme>
 </component>

--- a/src/cli/commands/CMakeLists.txt
+++ b/src/cli/commands/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(cli_commands STATIC Command.h CommandFactory.cpp CommandFactory.h IntegrateCommand.cpp IntegrateCommand.h UnintegrateCommand.h UnintegrateCommand.cpp exceptions.h)
+add_library(cli_commands OBJECT Command.h CommandFactory.cpp CommandFactory.h IntegrateCommand.cpp IntegrateCommand.h UnintegrateCommand.h UnintegrateCommand.cpp exceptions.h)
 target_link_libraries(cli_commands PUBLIC Qt5::Core shared cli_logging)
 target_include_directories(cli_commands PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -227,7 +227,6 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    watcher.startWatching();
     QObject::connect(&app, &QCoreApplication::aboutToQuit, &watcher, &FileSystemWatcher::stopWatching);
 
     auto* binaryUpdatesMonitor = setupBinaryUpdatesMonitor(argv);

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
 
     // watchers are kind of value objects, the watched directories may not change over the lifetime of the object
     // therefore we need to create a set beforehand, containing all directories we want to have watched
-    QSet<QString> watchedDirectories;
+    QDirSet watchedDirectories;
 
     // of course we need to watch the main integration directory
     const auto defaultDestination = integratedAppImagesDestination();
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
     // this option is for debugging the
     if (listWatchedDirectories) {
         for (const auto& watchedDir : watchedDirectories) {
-            std::cout << watchedDir.toStdString() << std::endl;
+            std::cout << watchedDir.absolutePath().toStdString() << std::endl;
         }
         return 0;
     }
@@ -132,7 +132,7 @@ int main(int argc, char* argv[]) {
     // initial search for AppImages; if AppImages are found, they will be integrated, unless they already are
     std::cout << "Searching for existing AppImages" << std::endl;
     for (const auto& dir : watcher.directories()) {
-        std::cout << "Searching directory: " << dir.toStdString() << std::endl;
+        std::cout << "Searching directory: " << dir.absolutePath().toStdString() << std::endl;
         for (QDirIterator it(dir); it.hasNext();) {
             const auto& path = it.next();
             if (QFileInfo(path).isFile()) {
@@ -166,7 +166,7 @@ int main(int argc, char* argv[]) {
 
     std::cout << "Watching directories: ";
     for (const auto& dir : watcher.directories()) {
-        std::cout << dir.toStdString().c_str() << " ";
+        std::cout << dir.absolutePath().toStdString().c_str() << " ";
     }
     std::cout << std::endl;
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char* argv[]) {
     watcher.startWatching();
     QObject::connect(&app, &QCoreApplication::aboutToQuit, &watcher, &FileSystemWatcher::stopWatching);
 
-    QTimer* binaryUpdatesMonitor = setupBinaryUpdatesMonitor(argv);
+    auto* binaryUpdatesMonitor = setupBinaryUpdatesMonitor(argv);
     binaryUpdatesMonitor->start();
 
     return QCoreApplication::exec();

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
     // to watch
     // these
     QObject::connect(&watcher, &FileSystemWatcher::newDirectoriesToWatch, &app, [&worker](const QDirSet& newDirs) {
-        if (!newDirs.empty()) {
+        if (newDirs.empty()) {
             qDebug() << "No changes in watched directories detected";
         } else {
             std::cout << "Discovered new directories to watch, integrating existing AppImages initially" << std::endl;

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[]) {
     // these
     QObject::connect(&watcher, &FileSystemWatcher::newDirectoriesToWatch, &app, [&worker](const QDirSet& newDirs) {
         if (newDirs.empty()) {
-            qDebug() << "No changes in watched directories detected";
+            qDebug() << "No new directories to watch detected";
         } else {
             std::cout << "Discovered new directories to watch, integrating existing AppImages initially" << std::endl;
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -1,6 +1,7 @@
 // system includes
 #include <deque>
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <sys/stat.h>
 
@@ -52,22 +53,28 @@ QTimer* setupBinaryUpdatesMonitor(char* const* argv) {
     // check every 5 min
     timer->setInterval(5 * 60 * 1000);
     return timer;
+}
 
 void initialSearchForAppImages(const QDirSet& dirsToSearch, Worker& worker) {
     // initial search for AppImages; if AppImages are found, they will be integrated, unless they already are
     std::cout << "Searching for existing AppImages" << std::endl;
+
     for (const auto& dir : dirsToSearch) {
         std::cout << "Searching directory: " << dir.absolutePath().toStdString() << std::endl;
+
         for (QDirIterator it(dir); it.hasNext();) {
             const auto& path = it.next();
+
             if (QFileInfo(path).isFile()) {
                 const auto appImageType = appimage_get_type(path.toStdString().c_str(), false);
                 const auto isAppImage = 0 < appImageType && appImageType <= 2;
+
                 if (isAppImage) {
                     // at application startup, we don't want to integrate AppImages that have been integrated already,
                     // as that it slows down very much
                     // the integration will be updated as soon as any of these AppImages is run with AppImageLauncher
                     std::cout << "Found AppImage: " << path.toStdString() << std::endl;
+
                     if (!appimage_is_registered_in_system(path.toStdString().c_str())) {
                         std::cout << "AppImage is not integrated yet, integrating" << std::endl;
                         worker.scheduleForIntegration(path);
@@ -131,7 +138,7 @@ int main(int argc, char* argv[]) {
 
     // of course we need to watch the main integration directory
     const auto defaultDestination = integratedAppImagesDestination();
-    watchedDirectories.insert(defaultDestination.absolutePath());
+    watchedDirectories.insert(defaultDestination);
 
     const auto monitorMountedFilesystems = parser.isSet(monitorMountedFilesystemsOption);
     const auto listWatchedDirectories = parser.isSet(listWatchedDirectoriesOption);

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -188,6 +188,24 @@ int main(int argc, char* argv[]) {
         }
     });
 
+    // whenever a formerly watched directory disappears, we want to clean the menu from entries pointing to AppImages
+    // in this directory
+    // a good example for this situation is a removable drive that has been unplugged from the computer
+    QObject::connect(&watcher, &FileSystemWatcher::directoriesToWatchDisappeared, &app,
+        [](const QDirSet& disappearedDirs) {
+
+        if (disappearedDirs.empty()) {
+            qDebug() << "No directories disappeared";
+        } else {
+            std::cout << "Directories to watch disappeared, unintegrating AppImages formerly found in there"
+                      << std::endl;
+
+            if (!cleanUpOldDesktopIntegrationResources(true)) {
+                std::cerr << "Error: Failed to clean up old desktop integration resources" << std::endl;
+            }
+        }
+    });
+
     // search directories to watch once initially
     // we *have* to do this even though we connect this signal above, as the first update occurs in the constructor
     // and we cannot connect signals before construction has finished for obvious reasons

--- a/src/daemon/worker.cpp
+++ b/src/daemon/worker.cpp
@@ -4,6 +4,7 @@
 #include <deque>
 
 // library includes
+#include <QDebug>
 #include <QFile>
 #include <QObject>
 #include <QSysInfo>
@@ -117,6 +118,7 @@ Worker::Worker() {
 
 void Worker::executeDeferredOperations() {
     if (d->deferredOperations.empty()) {
+        qDebug() << "No deferred operations to execute";
         return;
     }
 

--- a/src/daemon/worker.cpp
+++ b/src/daemon/worker.cpp
@@ -116,6 +116,10 @@ Worker::Worker() {
 }
 
 void Worker::executeDeferredOperations() {
+    if (d->deferredOperations.empty()) {
+        return;
+    }
+
     std::cout << "Executing deferred operations" << std::endl;
 
     auto outputMutex = std::make_shared<QMutex>();

--- a/src/fswatcher/CMakeLists.txt
+++ b/src/fswatcher/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(filesystemwatcher STATIC filesystemwatcher.cpp filesystemwatcher.h)
+add_library(filesystemwatcher OBJECT filesystemwatcher.cpp filesystemwatcher.h)
 target_link_libraries(filesystemwatcher PUBLIC Qt5::Core)
 target_include_directories(filesystemwatcher PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -6,6 +6,7 @@
 // library includes
 #include <QDebug>
 #include <QDir>
+#include <QMutex>
 #include <QTimer>
 #include <QThread>
 #include <sys/inotify.h>
@@ -37,6 +38,7 @@ public:
 public:
     QDirSet watchedDirectories;
     QTimer eventsLoopTimer;
+    QMutex* mutex;
 
 private:
     int inotifyFd = -1;
@@ -45,6 +47,9 @@ private:
 public:
     // reads events from the inotify fd and emits the correct signals
     std::vector<INotifyEvent> readEventsFromFd() {
+        // we don't want to read events in parallel
+        QMutexLocker lock{mutex};
+
         // read raw bytes into buffer
         // this is necessary, as the inotify_events have dynamic sizes
         static const auto bufSize = 4096;
@@ -86,7 +91,7 @@ public:
         return events;
     }
 
-    PrivateData() : isRunning(false), watchedDirectories() {
+    PrivateData() : isRunning(false), watchedDirectories(), mutex(new QMutex) {
         inotifyFd = inotify_init1(IN_NONBLOCK);
         if (inotifyFd < 0) {
             auto error = errno;
@@ -94,6 +99,7 @@ public:
         }
     };
 
+    // caution: method is not threadsafe!
     bool startWatching(const QDir& directory) {
         static const auto mask = fileChangeEvents | fileRemovalEvents;
 
@@ -119,6 +125,8 @@ public:
     }
 
     bool startWatching() {
+        QMutexLocker lock{mutex};
+
         for (const auto& directory : watchedDirectories) {
             if (!startWatching(directory))
                 return false;
@@ -128,6 +136,8 @@ public:
     }
 
     bool startWatching(const QDirSet& directories) {
+        QMutexLocker lock{mutex};
+
         for (const auto& directory : directories) {
             if (!startWatching(directory)) {
                 return false;
@@ -137,6 +147,7 @@ public:
         return true;
     }
 
+    // caution: method is not threadsafe!
     bool stopWatching(int watchFd) {
         // no matter whether the watch removal succeeds, retrying to remove the watch won't help
         // therefore, we can remove the file descriptor from the map in any case
@@ -154,6 +165,8 @@ public:
     }
 
     bool stopWatching() {
+        QMutexLocker lock{mutex};
+
         while (!watchFdMap.empty()) {
             const auto pair = *(watchFdMap.begin());
             const auto watchFd = pair.first;
@@ -169,6 +182,8 @@ public:
     }
 
     bool stopWatching(const QDirSet& directories) {
+        QMutexLocker lock{mutex};
+
         for (const auto& directory : directories) {
             for (const auto& pair : watchFdMap) {
                 if (pair.second == directory) {
@@ -202,33 +217,51 @@ FileSystemWatcher::FileSystemWatcher(const QDirSet& paths) : FileSystemWatcher()
 }
 
 QDirSet FileSystemWatcher::directories() {
+    QMutexLocker lock{d->mutex};
+
     return d->watchedDirectories;
 }
 
 bool FileSystemWatcher::startWatching() {
-    if (d->isRunning) {
-        qDebug() << "tried to start file system watcher while it's running already";
-        return true;
+    {
+        QMutexLocker lock{d->mutex};
+
+        if (d->isRunning) {
+            qDebug() << "tried to start file system watcher while it's running already";
+            return true;
+        }
     }
 
     auto rv = d->startWatching();
 
-    if (rv)
-        d->isRunning = true;
+    {
+        QMutexLocker lock{d->mutex};
+
+        if (rv)
+            d->isRunning = true;
+    }
 
     return rv;
 }
 
 bool FileSystemWatcher::stopWatching() {
-    if (!d->isRunning) {
-        qDebug() << "tried to stop file system watcher while stopped";
-        return true;
+    {
+        QMutexLocker lock{d->mutex};
+
+        if (!d->isRunning) {
+            qDebug() << "tried to stop file system watcher while stopped";
+            return true;
+        }
     }
 
     const auto rv = d->stopWatching();
 
-    if (rv)
-        d->isRunning = false;
+    {
+        QMutexLocker lock{d->mutex};
+
+        if (rv)
+            d->isRunning = false;
+    }
 
     return rv;
 }
@@ -292,15 +325,17 @@ bool FileSystemWatcher::updateWatchedDirectories(QDirSet watchedDirectories) {
     // to stop watching with a fine granularity, we also need to know which directories have been removed
     QDirSet disappearedDirectories = setDifference(d->watchedDirectories, watchedDirectories);
 
-    emit newDirectoriesToWatch(newDirectories);
+    {
+        QMutexLocker lock{d->mutex};
 
-    // now we can update the internal state
-    d->watchedDirectories = watchedDirectories;
+        // now we can update the internal state
+        d->watchedDirectories = watchedDirectories;
 
-    // if the watching hasn't been started yet, we shouldn't start/stop any watches
-    // unfortunately we need an extra variable to track this...
-    if (!d->isRunning)
-        return true;
+        // if the watching hasn't been started yet, we shouldn't start/stop any watches
+        // unfortunately we need an extra variable to track this...
+        if (!d->isRunning)
+            return true;
+    }
 
     if (!d->stopWatching(disappearedDirectories))
         return false;

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -93,9 +93,10 @@ public:
 
     PrivateData() : isRunning(false), watchedDirectories(), mutex(new QMutex) {
         inotifyFd = inotify_init1(IN_NONBLOCK);
+
         if (inotifyFd < 0) {
             auto error = errno;
-            throw FileSystemWatcherError(strerror(error));
+            throw FileSystemWatcherError(QString("Failed to initialize inotify, reason: ") + strerror(error));
         }
     };
 

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -177,8 +177,6 @@ public:
             }
         }
 
-        eventsLoopTimer.stop();
-
         return true;
     }
 
@@ -260,8 +258,12 @@ bool FileSystemWatcher::stopWatching() {
     {
         QMutexLocker lock{d->mutex};
 
-        if (rv)
+        if (rv) {
             d->isRunning = false;
+
+            // we can stop reporting events now, I guess
+            d->eventsLoopTimer.stop();
+        }
     }
 
     return rv;

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -348,6 +348,7 @@ bool FileSystemWatcher::updateWatchedDirectories(QDirSet watchedDirectories) {
 
     // send out the signals for further handling by users of a fs watcher instance
     emit newDirectoriesToWatch(newDirectories);
+    emit directoriesToWatchDisappeared(disappearedDirectories);
 
     return true;
 }

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -95,7 +95,7 @@ public:
 
         if (!directory.exists()) {
             std::cerr << "Warning: directory " << directory.absolutePath().toStdString()
-                      << "does not exist, skipping" << std::endl;
+                      << " does not exist, skipping" << std::endl;
             return true;
         }
 

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -229,24 +229,16 @@ bool FileSystemWatcher::updateWatchedDirectories(QDirSet watchedDirectories) {
     }
 
     // first, we calculate which directores are new to be watched
-    QDirSet changedDirectories;
+    QDirSet newDirectories;
 
-    for (const auto& i : watchedDirectories) {
-        bool entryFound = false;
+    std::set_difference(
+        watchedDirectories.begin(), watchedDirectories.end(),
+        d->watchedDirectories.begin(), d->watchedDirectories.end(),
+        std::inserter(newDirectories, newDirectories.end()),
+        QDirComparator{}
+    );
 
-        for (const auto& j : d->watchedDirectories) {
-            if (i == j) {
-                entryFound = true;
-                break;
-            }
-        }
-
-        if (!entryFound) {
-            changedDirectories.insert(i);
-        }
-    }
-
-    emit newDirectoriesToWatch(changedDirectories);
+    emit newDirectoriesToWatch(newDirectories);
 
     // now we can update the internal state
     d->watchedDirectories = watchedDirectories;

--- a/src/fswatcher/filesystemwatcher.cpp
+++ b/src/fswatcher/filesystemwatcher.cpp
@@ -340,15 +340,15 @@ bool FileSystemWatcher::updateWatchedDirectories(QDirSet watchedDirectories) {
             return true;
     }
 
-    if (!d->stopWatching(disappearedDirectories))
-        return false;
-
-    if (!d->startWatching(newDirectories))
-        return false;
+    // we must run both stop and start methods, so we cannot directly return false if either fails
+    // also, this makes sure the signals are sent even in case either of the following methods fails
+    bool rv = true;
+    rv = rv && d->stopWatching(disappearedDirectories);
+    rv = rv && d->startWatching(newDirectories);
 
     // send out the signals for further handling by users of a fs watcher instance
     emit newDirectoriesToWatch(newDirectories);
     emit directoriesToWatchDisappeared(disappearedDirectories);
 
-    return true;
+    return rv;
 }

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -22,7 +22,7 @@ public:
 struct QDirComparator {
 public:
     size_t operator()(const QDir& a, const QDir& b) const {
-        return a == b;
+        return a.absolutePath() < b.absolutePath();
     }
 };
 

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -26,11 +26,9 @@ public:
     explicit FileSystemWatcher(const QSet<QString>& paths);
     FileSystemWatcher();
 
-public:
+public slots:
     bool startWatching();
     bool stopWatching();
-
-public slots:
     void readEvents();
 
 public:

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -58,4 +58,5 @@ signals:
     void fileChanged(QString path);
     void fileRemoved(QString path);
     void newDirectoriesToWatch(QDirSet set);
+    void directoriesToWatchDisappeared(QDirSet set);
 };

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -42,7 +42,7 @@ public slots:
     bool startWatching();
     bool stopWatching();
     void readEvents();
-    bool updateWatchedDirectories(const QDirSet& watchedDirectories);
+    bool updateWatchedDirectories(QDirSet watchedDirectories);
 
 public:
     QDirSet directories();

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -42,6 +42,7 @@ public slots:
     bool startWatching();
     bool stopWatching();
     void readEvents();
+    bool updateWatchedDirectories(const QDirSet& watchedDirectories);
 
 public:
     QDirSet directories();
@@ -49,4 +50,5 @@ public:
 signals:
     void fileChanged(QString path);
     void fileRemoved(QString path);
+    void newDirectoriesToWatch(QDirSet set);
 };

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -19,7 +19,14 @@ public:
     }
 };
 
-typedef std::unordered_set<QDir, QDirHash> QDirSet;
+struct QDirComparator {
+public:
+    size_t operator()(const QDir& a, const QDir& b) const {
+        return a == b;
+    }
+};
+
+typedef std::unordered_set<QDir, QDirHash, QDirComparator> QDirSet;
 
 class FileSystemWatcherError : public std::runtime_error {
 public:

--- a/src/fswatcher/filesystemwatcher.h
+++ b/src/fswatcher/filesystemwatcher.h
@@ -1,13 +1,25 @@
 // system includes
+#include <algorithm>
 #include <memory>
+#include <unordered_set>
 
 // library includes
+#include <QDir>
 #include <QObject>
 #include <QSet>
 #include <QString>
 #include <QThread>
 
 #pragma once
+
+struct QDirHash {
+public:
+    size_t operator()(const QDir& dir) const {
+        return qt_hash(dir.absolutePath());
+    }
+};
+
+typedef std::unordered_set<QDir, QDirHash> QDirSet;
 
 class FileSystemWatcherError : public std::runtime_error {
 public:
@@ -22,8 +34,8 @@ private:
     std::shared_ptr<PrivateData> d;
 
 public:
-    explicit FileSystemWatcher(const QString& path);
-    explicit FileSystemWatcher(const QSet<QString>& paths);
+    explicit FileSystemWatcher(const QDir& directory);
+    explicit FileSystemWatcher(const QDirSet& paths);
     FileSystemWatcher();
 
 public slots:
@@ -32,7 +44,7 @@ public slots:
     void readEvents();
 
 public:
-    QSet<QString> directories();
+    QDirSet directories();
 
 signals:
     void fileChanged(QString path);

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -305,12 +305,12 @@ QSet<QString> additionalAppImagesLocations(const bool includeAllMountPoints) {
     static const auto validFilesystems = {"ext2", "ext3", "ext4", "ntfs", "vfat"};
 
     static const auto blacklistedMountPointPrefixes = {
-        "/var/lib/schroot/",
-        "/run/docker/",
-        "/boot/",
-        "/sys/",
-        "/proc/",
-        "/snap/",
+        "/var/lib/schroot",
+        "/run/docker",
+        "/boot",
+        "/sys",
+        "/proc",
+        "/snap",
     };
 
     if (includeAllMountPoints) {
@@ -340,7 +340,7 @@ QSet<QString> additionalAppImagesLocations(const bool includeAllMountPoints) {
             // either it's a waste of time or otherwise a bad idea, but it will surely save time *not* to search them
             if (std::find_if(blacklistedMountPointPrefixes.begin(), blacklistedMountPointPrefixes.end(),
                              [&mountPoint](const QString& prefix) {
-                                 return mountPoint.startsWith(prefix);
+                                 return mountPoint == prefix || mountPoint.startsWith(prefix + "/");
                              }) != blacklistedMountPointPrefixes.end()) {
                 continue;
             }

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -404,7 +404,10 @@ std::map<std::string, std::string> findCollisions(const QString& currentNameEntr
     std::map<std::string, std::string> collisions{};
 
     // default locations of desktop files on systems
-    const auto directories = {QString("/usr/share/applications/"), QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/applications/"};
+    const auto directories = {
+        QString("/usr/share/applications/"),
+        QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/applications/"
+    };
 
     for (const auto& directory : directories) {
         QDirIterator iterator(directory, QDirIterator::FollowSymlinks);
@@ -438,12 +441,14 @@ std::map<std::string, std::string> findCollisions(const QString& currentNameEntr
 }
 
 bool updateDesktopDatabaseAndIconCaches() {
+    const auto dataLocation = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+
     const std::map<std::string, std::string> commands = {
-        {"update-desktop-database", "~/.local/share/applications"},
-        {"gtk-update-icon-cache-3.0", "~/.local/share/icons/hicolor/ -t"},
-        {"gtk-update-icon-cache", "~/.local/share/icons/hicolor/ -t"},
+        {"update-desktop-database", dataLocation.toStdString() + "/applications"},
+        {"gtk-update-icon-cache-3.0", dataLocation.toStdString() + "/icons/hicolor/ -t"},
+        {"gtk-update-icon-cache", dataLocation.toStdString() + "/icons/hicolor/ -t"},
         {"xdg-desktop-menu", "forceupdate"},
-        {"update-mime-database", "~/.local/share/mime "},
+        {"update-mime-database", dataLocation.toStdString() + "/mime "},
     };
 
     for (const auto& command : commands) {
@@ -938,7 +943,10 @@ bool cleanUpOldDesktopIntegrationResources(bool verbose) {
             auto* iconValue = g_key_file_get_string(desktopFile.get(), G_KEY_FILE_DESKTOP_GROUP, G_KEY_FILE_DESKTOP_KEY_ICON, nullptr);
 
             if (iconValue != nullptr) {
-                for (QDirIterator it("~/.local/share/icons/", QDirIterator::Subdirectories); it.hasNext();) {
+                const auto dataLocation = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+                const auto iconsPath = QString::fromStdString(dataLocation.toStdString() + "/share/icons/");
+
+                for (QDirIterator it(iconsPath, QDirIterator::Subdirectories); it.hasNext();) {
                     auto path = it.next();
 
                     if (QFileInfo(path).completeBaseName().startsWith(iconValue)) {

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -401,7 +401,7 @@ QString buildPathToIntegratedAppImage(const QString& pathToAppImage) {
 }
 
 std::map<std::string, std::string> findCollisions(const QString& currentNameEntry) {
-    std::map<std::string, std::string> collisions;
+    std::map<std::string, std::string> collisions{};
 
     // default locations of desktop files on systems
     const auto directories = {QString("/usr/share/applications/"), QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/applications/"};

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -67,7 +67,7 @@ QDir integratedAppImagesDestination();
 
 // additional directories to monitor for AppImages, and to permit AppImages to be within (i.e., shall not ask whether
 // to move to the main location, if they're in one of these, it's all good)
-QSet<QString> additionalAppImagesLocations();
+QSet<QString> additionalAppImagesLocations(bool includeValidMountPoints = false);
 
 // build path to standard location for integrated AppImages
 QString buildPathToIntegratedAppImage(const QString& pathToAppImage);


### PR DESCRIPTION
Fixes #154.

You can switch on this feature by calling appimagelauncherd with the flag `--monitor-mounted-filesystems`. We could also make this a setting at some point.

@probonopd please try out the feature ASAP, as you requested it. This is a pretty new and right now experimental feature that requires some testing. But once I'm completely done with the remaining tasks, we can release the first beta for 2.0.0.