### PR TITLE
Build distro specific binaries for Ubuntu {disco,eoan}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ matrix:
       name: Native packages for Ubuntu xenial, Debian stable etc., x86_64
     - env: DIST=xenial ARCH=i386
       name: Native packages for Ubuntu xenial, Debian stable etc., i386
+    - env: DIST=disco ARCH=x86_64
+      name: Native packages for Ubuntu disco, x86_64
+    - env: DIST=disco ARCH=i386
+      name: Native packages for Ubuntu disco, i386
+    - env: DIST=eoan ARCH=x86_64
+      name: Native packages for Ubuntu eoan, x86_64
+    - env: DIST=eoan ARCH=i386
+      name: Native packages for Ubuntu eoan, i386
     - env: DIST=bionic ARCH=x86_64 BUILD_LITE=1
       name: AppImageLauncher Lite AppImage x86_64
     - env: DIST=bionic ARCH=i386 BUILD_LITE=1

--- a/travis/Dockerfile.build-disco
+++ b/travis/Dockerfile.build-disco
@@ -1,0 +1,35 @@
+# used to cache installed dependencies for bionic builds
+# this speeds up builds during development, as the dependencies are just installed _once_
+
+FROM ubuntu:disco
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install qt5-default \
+        qtbase5-dev \
+        qt5-qmake \
+        libcurl4-openssl-dev \
+        libfuse-dev \
+        desktop-file-utils \
+        libglib2.0-dev \
+        libcairo2-dev \
+        libssl-dev \
+        ca-certificates \
+        libbsd-dev \
+        qttools5-dev-tools \
+        \
+        gcc \
+        g++ \
+        cmake \
+        make \
+        git \
+        automake \
+        autoconf \
+        libtool \
+        patch \
+        wget \
+        vim-common \
+        desktop-file-utils \
+        pkg-config \
+        libarchive-dev \
+        libboost-filesystem-dev \
+        librsvg2-dev

--- a/travis/Dockerfile.build-disco-i386-cross
+++ b/travis/Dockerfile.build-disco-i386-cross
@@ -1,0 +1,50 @@
+# used to cache installed dependencies for bionic builds
+# this speeds up builds during development, as the dependencies are just installed _once_
+
+FROM i386/ubuntu:disco
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        libfuse2:i386 \
+        qtbase5-dev:i386 \
+        qt5-qmake:i386 \
+        qtbase5-dev-tools:i386 \
+        libqt5core5a:i386 \
+        libqt5gui5:i386 \
+        libcurl4-openssl-dev:i386 \
+        libssl-dev:i386 \
+        libqt5widgets5:i386 \
+        librsvg2-bin:i386 \
+        libfuse-dev:i386 \
+        libcurl4:i386 \
+        libcurl4 \
+        libbsd-dev:i386 \
+        libglib2.0-dev:i386 \
+        liblzma-dev:i386 \
+        libgtest-dev \
+        libcairo-dev:i386 \
+        libgl1-mesa-dev:i386 \
+        libglu1-mesa-dev:i386 \
+        \
+        rpm \
+        gcc-multilib \
+        g++-multilib \
+        cmake \
+        make \
+        git \
+        ca-certificates \
+        automake \
+        autoconf \
+        libtool \
+        patch \
+        wget \
+        vim-common \
+        desktop-file-utils \
+        pkg-config \
+        qttools5-dev-tools:i386 \
+        qt5-qmake-bin:i386 \
+        libarchive-dev:i386 \
+        libboost-filesystem-dev:i386 \
+        zlib1g:i386 \
+        librsvg2-dev:i386

--- a/travis/Dockerfile.build-eoan
+++ b/travis/Dockerfile.build-eoan
@@ -1,0 +1,35 @@
+# used to cache installed dependencies for bionic builds
+# this speeds up builds during development, as the dependencies are just installed _once_
+
+FROM ubuntu:eoan
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install qt5-default \
+        qtbase5-dev \
+        qt5-qmake \
+        libcurl4-openssl-dev \
+        libfuse-dev \
+        desktop-file-utils \
+        libglib2.0-dev \
+        libcairo2-dev \
+        libssl-dev \
+        ca-certificates \
+        libbsd-dev \
+        qttools5-dev-tools \
+        \
+        gcc \
+        g++ \
+        cmake \
+        make \
+        git \
+        automake \
+        autoconf \
+        libtool \
+        patch \
+        wget \
+        vim-common \
+        desktop-file-utils \
+        pkg-config \
+        libarchive-dev \
+        libboost-filesystem-dev \
+        librsvg2-dev

--- a/travis/Dockerfile.build-eoan-i386-cross
+++ b/travis/Dockerfile.build-eoan-i386-cross
@@ -1,0 +1,50 @@
+# used to cache installed dependencies for bionic builds
+# this speeds up builds during development, as the dependencies are just installed _once_
+
+FROM i386/ubuntu:eoan
+
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        libfuse2:i386 \
+        qtbase5-dev:i386 \
+        qt5-qmake:i386 \
+        qtbase5-dev-tools:i386 \
+        libqt5core5a:i386 \
+        libqt5gui5:i386 \
+        libcurl4-openssl-dev:i386 \
+        libssl-dev:i386 \
+        libqt5widgets5:i386 \
+        librsvg2-bin:i386 \
+        libfuse-dev:i386 \
+        libcurl4:i386 \
+        libcurl4 \
+        libbsd-dev:i386 \
+        libglib2.0-dev:i386 \
+        liblzma-dev:i386 \
+        libgtest-dev \
+        libcairo-dev:i386 \
+        libgl1-mesa-dev:i386 \
+        libglu1-mesa-dev:i386 \
+        \
+        rpm \
+        gcc-multilib \
+        g++-multilib \
+        cmake \
+        make \
+        git \
+        ca-certificates \
+        automake \
+        autoconf \
+        libtool \
+        patch \
+        wget \
+        vim-common \
+        desktop-file-utils \
+        pkg-config \
+        qttools5-dev-tools:i386 \
+        qt5-qmake-bin:i386 \
+        libarchive-dev:i386 \
+        libboost-filesystem-dev:i386 \
+        zlib1g:i386 \
+        librsvg2-dev:i386

--- a/travis/travis-docker.sh
+++ b/travis/travis-docker.sh
@@ -11,7 +11,7 @@ set -e
 export DOCKER_DIST="$1"
 
 case "$DOCKER_DIST" in
-    xenial|bionic)
+    xenial|bionic|disco|eoan)
         ;;
     *)
         echo "Error: invalid/unsupported distro: $DOCKER_DIST"
@@ -41,5 +41,11 @@ else
     build_script=build-lite.sh
 fi
 
-docker run -e ARCH -e TRAVIS_BUILD_NUMBER --rm -it -v $(readlink -f ..):/ws "$IMAGE" \
+DOCKER_OPTS=()
+# fix for https://stackoverflow.com/questions/51195528/rcc-error-in-resource-qrc-cannot-find-file-png
+if [ "$TRAVIS" != "" ]; then
+    DOCKER_OPTS+=("--security-opt" "seccomp:unconfined")
+fi
+
+docker run -e ARCH -e TRAVIS_BUILD_NUMBER --rm -it "${DOCKER_OPTS[@]}" -v $(readlink -f ..):/ws "$IMAGE" \
     bash -xc "export CI=1 && export DEBIAN_DIST=\"$DOCKER_DIST\" && cd /ws && source travis/$build_script"


### PR DESCRIPTION
Fixes #252.

@camckay @ThisNekoGuy please test the following binaries (depending on your distro and arch):

- https://artifacts.assassinate-you.net/artifactory/AppImageLauncher/travis-871/appimagelauncher_2.0.0-travis871~97b6c96%2Bdisco_amd64.deb
- https://artifacts.assassinate-you.net/artifactory/AppImageLauncher/travis-871/appimagelauncher_2.0.0-travis871~97b6c96%2Bdisco_i386.deb
- https://artifacts.assassinate-you.net/artifactory/AppImageLauncher/travis-871/appimagelauncher_2.0.0-travis871~97b6c96%2Beoan_amd64.deb
- https://artifacts.assassinate-you.net/artifactory/AppImageLauncher/travis-871/appimagelauncher_2.0.0-travis871~97b6c96%2Beoan_i386.deb

This PR can be merged once you can confirm they fix the runtime issues.

It's pretty annoying to have to build distro-specific packages again, by the way. Every new configuration delays the build significantly, as on Travis CI, you only have a limit of 5(?) parallel jobs for a single job.