### PR TITLE
Build ARM64 binaries on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       name: Native packages for Ubuntu xenial, Debian stable etc., x86_64
     - env: DIST=xenial ARCH=i386
       name: Native packages for Ubuntu xenial, Debian stable etc., i386
+    - env: DIST=bionic ARCH=arm64
+      name: Native packages for Ubuntu bionic, Debian testing and newer, arm64
+      arch: arm64
     - env: DIST=bionic ARCH=x86_64 BUILD_LITE=1
       name: AppImageLauncher Lite AppImage x86_64
     - env: DIST=bionic ARCH=i386 BUILD_LITE=1

--- a/travis/Dockerfile.build-bionic-arm64
+++ b/travis/Dockerfile.build-bionic-arm64
@@ -19,7 +19,6 @@ RUN apt-get update && \
         \
         gcc \
         g++ \
-        cmake \
         make \
         git \
         automake \
@@ -33,3 +32,11 @@ RUN apt-get update && \
         libarchive-dev \
         libboost-filesystem-dev \
         librsvg2-dev
+
+RUN wget -O- https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz | tar xz && \
+    pushd cmake-3.16.4/ && \
+    ./configure --prefix=/usr && \
+    make -j$(nproc) && \
+    make install && \
+    popd && \
+    rm -rf cmake-3.16.4/

--- a/travis/Dockerfile.build-bionic-arm64
+++ b/travis/Dockerfile.build-bionic-arm64
@@ -34,9 +34,9 @@ RUN apt-get update && \
         librsvg2-dev
 
 RUN wget -O- https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4.tar.gz | tar xz && \
-    pushd cmake-3.16.4/ && \
+    cd cmake-3.16.4/ && \
     ./configure --prefix=/usr && \
     make -j$(nproc) && \
     make install && \
-    popd && \
+    cd - && \
     rm -rf cmake-3.16.4/

--- a/travis/Dockerfile.build-bionic-arm64
+++ b/travis/Dockerfile.build-bionic-arm64
@@ -1,0 +1,35 @@
+# used to cache installed dependencies for bionic builds
+# this speeds up builds during development, as the dependencies are just installed _once_
+
+FROM arm64v8/ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get -y --no-install-recommends install qt5-default \
+        qtbase5-dev \
+        qt5-qmake \
+        libcurl4-openssl-dev \
+        libfuse-dev \
+        desktop-file-utils \
+        libglib2.0-dev \
+        libcairo2-dev \
+        libssl-dev \
+        ca-certificates \
+        libbsd-dev \
+        qttools5-dev-tools \
+        \
+        gcc \
+        g++ \
+        cmake \
+        make \
+        git \
+        automake \
+        autoconf \
+        libtool \
+        patch \
+        wget \
+        vim-common \
+        desktop-file-utils \
+        pkg-config \
+        libarchive-dev \
+        libboost-filesystem-dev \
+        librsvg2-dev

--- a/travis/travis-build.sh
+++ b/travis/travis-build.sh
@@ -32,10 +32,13 @@ pushd "$BUILD_DIR"
 # install more recent CMake version which fixes some linking issue in CMake < 3.10
 # Fixes https://github.com/TheAssassin/AppImageLauncher/issues/106
 # Upstream bug: https://gitlab.kitware.com/cmake/cmake/issues/17389
-wget https://cmake.org/files/v3.13/cmake-3.13.2-Linux-x86_64.tar.gz -qO- | tar xz --strip-components=1
-export PATH=$(readlink -f bin/):"$PATH"
-which cmake
-cmake --version
+# unfortunately, there's only AMD64 packges, so we skip this step for ARM64 builds
+if [ "$ARCH" != "arm64" ]; then
+    wget https://cmake.org/files/v3.13/cmake-3.13.2-Linux-x86_64.tar.gz -qO- | tar xz --strip-components=1
+    export PATH=$(readlink -f bin/):"$PATH"
+    which cmake
+    cmake --version
+fi
 
 if [ "$DEBIAN_DIST" != "" ]; then
     EXTRA_CMAKE_FLAGS=-DCPACK_DEBIAN_COMPATIBILITY_LEVEL="$DEBIAN_DIST"

--- a/travis/travis-docker.sh
+++ b/travis/travis-docker.sh
@@ -15,14 +15,17 @@ cd $(readlink -f $(dirname "$0"))
 IMAGE=quay.io/appimagelauncher-build/"$DOCKER_DIST"
 DOCKERFILE=Dockerfile.build-"$DOCKER_DIST"
 
-if [ ! -f "$DOCKERFILE" ]; then
-    echo "Error: $DOCKERFILE could not be found"
-    exit 1
-fi
-
 if [ "$ARCH" == "i386" ]; then
     IMAGE="$IMAGE"-i386-cross
     DOCKERFILE=Dockerfile.build-"$DOCKER_DIST"-i386-cross
+elif [ "$ARCH" == "arm64" ]; then
+    IMAGE=arm64v8/"$IMAGE"
+    DOCKERFILE=Dockerfile.build-"$DOCKER_DIST"-arm64
+fi
+
+if [ ! -f "$DOCKERFILE" ]; then
+    echo "Error: $DOCKERFILE could not be found"
+    exit 1
 fi
 
 # speed up build by pulling last built image from quay.io and building the docker file using the old image as a base

--- a/travis/travis-docker.sh
+++ b/travis/travis-docker.sh
@@ -19,7 +19,7 @@ if [ "$ARCH" == "i386" ]; then
     IMAGE="$IMAGE"-i386-cross
     DOCKERFILE=Dockerfile.build-"$DOCKER_DIST"-i386-cross
 elif [ "$ARCH" == "arm64" ]; then
-    IMAGE=arm64v8/"$IMAGE"
+    IMAGE="$IMAGE"-arm64
     DOCKERFILE=Dockerfile.build-"$DOCKER_DIST"-arm64
 fi
 

--- a/travis/travis-docker.sh
+++ b/travis/travis-docker.sh
@@ -46,7 +46,7 @@ if [ "$TRAVIS" != "" ]; then
     DOCKER_OPTS+=("--security-opt" "seccomp:unconfined")
 fi
 
-docker run -e ARCH -e TRAVIS_BUILD_NUMBER --rm -it "${DOCKER_OPTS[@]}" -v $(readlink -f ..):/ws "$IMAGE" \
+docker run -e ARCH -e TRAVIS_BUILD_NUMBER --rm -i "${DOCKER_OPTS[@]}" -v $(readlink -f ..):/ws "$IMAGE" \
     bash -xc "export CI=1 && export DEBIAN_DIST=\"$DOCKER_DIST\" && cd /ws && source travis/$build_script"
 
 # push built image as cache for future builds to registry


### PR DESCRIPTION
Travis recently added "native" ARM64 support (well, it's emulated or so, but at least for us it's transparent). This allows us to build binaries for Raspberry Pi & Co. (at least the ones running ARM64 images, which should be all except the ones running on some ARMv6 chips like both 1, Zero etc.).

The packages should also work on other ARM64 systems like e.g., the Pinebook, Pine64, ...

CC #293 