### PR TITLE
Add fallback icons

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -21,7 +21,7 @@ install(
 
 install(
     DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fallback-icons
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/appimagelauncher
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/appimagelauncher COMPONENT APPIMAGELAUNCHER
 )
 # we also need to copy the files into the binary dir to make their path predictable relative to the binary's location
 file(

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -19,6 +19,16 @@ install(
     DESTINATION ${CMAKE_INSTALL_DATADIR}/applications COMPONENT APPIMAGELAUNCHER
 )
 
+install(
+    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fallback-icons
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/appimagelauncher
+)
+# we also need to copy the files into the binary dir to make their path predictable relative to the binary's location
+file(
+    COPY "${CMAKE_CURRENT_SOURCE_DIR}/fallback-icons"
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 set(INSTALL_MAINTAINER_SCRIPTS OFF CACHE BOOL "")
 
 # install maintainer scripts that distro packagers might find useful

--- a/resources/fallback-icons/.gitignore
+++ b/resources/fallback-icons/.gitignore
@@ -1,0 +1,1 @@
+inkscape/

--- a/resources/fallback-icons/add.svg
+++ b/resources/fallback-icons/add.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333331 4.2333332"
+   height="16"
+   width="16">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-40.435481,-42.357438)"
+     id="layer1">
+    <g
+       id="text817"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.00854874px;line-height:283.70690918px;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0055d4;fill-opacity:1;stroke:none;stroke-width:0.41702288px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       aria-label="+">
+      <path
+         id="path2656"
+         style="font-size:7.78442764px;fill:#0055d4;stroke-width:0.41702288px"
+         d="m 44.194663,44.213326 v 0.521557 h -1.393412 v 1.385628 h -0.490419 v -1.385628 h -1.401197 v -0.521557 h 1.401197 v -1.385628 h 0.490419 v 1.385628 z" />
+    </g>
+  </g>
+</svg>

--- a/resources/fallback-icons/folder.svg
+++ b/resources/fallback-icons/folder.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333331 4.2333332"
+   height="16"
+   width="16">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-40.435481,-42.357438)"
+     id="layer1">
+    <g
+       id="text817"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.23638821px;line-height:148.43304443px;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0055d4;fill-opacity:1;stroke:none;stroke-width:0.21818285px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       aria-label="🖿">
+      <path
+         id="path814"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.07274675px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';fill:#0055d4;stroke-width:0.21818285px"
+         d="m 40.939339,45.934185 q -0.0896,0 -0.154764,-0.06516 -0.06109,-0.06516 -0.06109,-0.154764 v -2.468085 q 0,-0.09367 0.06516,-0.16291 0.06924,-0.06924 0.162909,-0.06924 h 1.132224 q 0.09367,0 0.158837,0.06924 0.06924,0.06924 0.06924,0.16291 v 0.126255 h 1.849027 q 0.09367,0 0.154764,0.06516 0.06516,0.06109 0.06516,0.154765 v 2.121901 q 0,0.0896 -0.06516,0.154764 -0.06109,0.06516 -0.154764,0.06516 z" />
+    </g>
+  </g>
+</svg>

--- a/resources/fallback-icons/found.svg
+++ b/resources/fallback-icons/found.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333331 4.2333332"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="found.regular.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="63.947933"
+     inkscape:cy="3.6765201"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="1920"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-40.435481,-42.357438)">
+    <g
+       aria-label="☑"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:180px;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#00d455;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text817">
+      <path
+         d="m 40.792909,42.673868 h 3.518476 l 0.01447,0.01447 v 3.569119 l -0.01447,0.01688 h -3.518476 l -0.01447,-0.01688 v -3.569119 z m 0.253215,0.265273 v 3.067513 h 3.009635 v -3.067513 z m 2.684074,0.381027 v 0.01447 q -0.183279,0.156752 -0.282154,0.296622 -0.788582,1.065913 -0.938099,1.844849 -0.01447,0.142283 -0.05306,0.142283 -0.282153,0.113343 -0.313503,0.113343 -0.243569,-0.622184 -0.73794,-0.622184 h -0.05547 v -0.01688 l 0.390674,-0.176044 q 0.364147,0 0.540191,0.315915 h 0.01447 q 0.12299,-0.40032 0.274919,-0.680062 0.236334,-0.43167 0.610126,-0.882633 0.233922,-0.289389 0.549838,-0.349678 z"
+         style="font-size:4.93888903px;fill:#00d455;stroke-width:0.26458332px"
+         id="path1957" />
+    </g>
+  </g>
+</svg>

--- a/resources/fallback-icons/missing.svg
+++ b/resources/fallback-icons/missing.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333331 4.2333332"
+   height="16"
+   width="16">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-40.435481,-42.357438)"
+     id="layer1">
+    <g
+       id="text817"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:6.3499999px;line-height:180px;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       aria-label="☒">
+      <path
+         id="path1979"
+         style="font-size:4.93888903px;fill:#ff0000;stroke-width:0.26458332px"
+         d="m 40.792909,42.673868 h 3.518476 l 0.01447,0.01447 v 3.569119 l -0.01447,0.01688 h -3.518476 l -0.01447,-0.01688 v -3.569119 z m 0.253215,0.265273 v 3.067513 h 3.009635 v -3.067513 z m 0.518487,0.32315 0.991154,0.981507 0.981507,-0.981507 0.229099,0.219452 -0.983919,0.991154 0.983919,0.988743 v 0.0072 l -0.219452,0.219453 -0.991154,-0.981508 h -0.0096 l -0.981507,0.974273 h -0.0096 l -0.219452,-0.219452 0.981507,-0.988743 -0.981507,-0.991154 z" />
+    </g>
+  </g>
+</svg>

--- a/resources/fallback-icons/remove.svg
+++ b/resources/fallback-icons/remove.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 4.2333331 4.2333332"
+   height="16"
+   width="16">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-40.435481,-42.357438)"
+     id="layer1">
+    <g
+       id="text817"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.98169994px;line-height:367.98522949px;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#0055d4;fill-opacity:1;stroke:none;stroke-width:0.54090416px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       transform="scale(1.2970612,0.77097365)"
+       aria-label="-">
+      <path
+         id="path2058"
+         style="font-size:10.09687901px;fill:#0055d4;stroke-width:0.54090416px"
+         d="m 31.600006,57.549329 h 2.413154 v 0.67649 h -2.413154 z" />
+    </g>
+  </g>
+</svg>

--- a/src/i18n/CMakeLists.txt
+++ b/src/i18n/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(translationmanager translationmanager.cpp translationmanager.h)
-target_link_libraries(translationmanager PUBLIC Qt5::Core Qt5::Widgets)
+target_link_libraries(translationmanager PUBLIC Qt5::Core Qt5::Widgets shared)
 target_include_directories(translationmanager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(translationmanager l10n)

--- a/src/i18n/translationmanager.cpp
+++ b/src/i18n/translationmanager.cpp
@@ -1,3 +1,6 @@
+// system headers
+#include <iostream>
+
 // library headers
 #include <QDebug>
 #include <QDir>
@@ -59,8 +62,8 @@ QString TranslationManager::getTranslationDir() {
 
     // give the user (and dev) some feedback whether the translations could actually be found or not
     if (!QDir(translationDir).exists()) {
-        qWarning() << "[AppImageLauncher] Warning:"
-                   << "Translation directory could not be found, translations are likely not available";
+        std::cerr << "[AppImageLauncher] Warning:"
+                  << "Translation directory could not be found, translations are likely not available" << std::endl;
     }
 
     return translationDir;

--- a/src/i18n/translationmanager.cpp
+++ b/src/i18n/translationmanager.cpp
@@ -56,7 +56,7 @@ QString TranslationManager::getTranslationDir() {
     if (!QDir(translationDir).exists()) {
         auto privateDataDir = pathToPrivateDataDirectory();
         if (!privateDataDir.isEmpty()) {
-            translationDir = +"/l10n";
+            translationDir = privateDataDir + "/l10n";
         }
     }
 

--- a/src/i18n/translationmanager.cpp
+++ b/src/i18n/translationmanager.cpp
@@ -5,6 +5,7 @@
 #include <QString>
 
 // local headers
+#include <shared.h>
 #include "translationmanager.h"
 
 TranslationManager::TranslationManager(QCoreApplication& app) : app(app) {
@@ -48,19 +49,12 @@ QString TranslationManager::getTranslationDir() {
     // therefore the files are now generated within the build dir, and we guess the path based on the binary location
     auto translationDir = binaryDirPath + "/../../i18n/generated/l10n";
 
-    // our helper tools are not shipped in usr/bin but usr/lib/<arch>-linux-gnu/appimagelauncher
-    // therefore we need to check for the translations directory relative to this directory as well
-    // as <arch-linux-gnu> may not be used in the path, we also check for its parent directory
+    // when the application is installed, we need to look for the files in the private data directory
     if (!QDir(translationDir).exists()) {
-        translationDir = binaryDirPath + "/../../share/appimagelauncher/l10n";
-    }
-    if (!QDir(translationDir).exists()) {
-        translationDir = binaryDirPath + "/../../../share/appimagelauncher/l10n";
-    }
-
-    // this directory should work for the main application in usr/bin
-    if (!QDir(translationDir).exists()) {
-        translationDir = binaryDirPath + "/../share/appimagelauncher/l10n";
+        auto privateDataDir = pathToPrivateDataDirectory();
+        if (privateDataDir != "") {
+            translationDir = +"/l10n";
+        }
     }
 
     // give the user (and dev) some feedback whether the translations could actually be found or not

--- a/src/i18n/translationmanager.cpp
+++ b/src/i18n/translationmanager.cpp
@@ -55,14 +55,14 @@ QString TranslationManager::getTranslationDir() {
     // when the application is installed, we need to look for the files in the private data directory
     if (!QDir(translationDir).exists()) {
         auto privateDataDir = pathToPrivateDataDirectory();
-        if (privateDataDir != "") {
+        if (!privateDataDir.isEmpty()) {
             translationDir = +"/l10n";
         }
     }
 
     // give the user (and dev) some feedback whether the translations could actually be found or not
     if (!QDir(translationDir).exists()) {
-        std::cerr << "[AppImageLauncher] Warning:"
+        std::cerr << "[AppImageLauncher] Warning: "
                   << "Translation directory could not be found, translations are likely not available" << std::endl;
     }
 

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -1314,8 +1314,8 @@ QIcon loadIconWithFallback(const QString& iconName) {
     // fallback icons aren't critical enough to exit the application if they can't be found
     // after all, the theme icons may work just as well
     if (!fallbackIconDirectory.exists()) {
-        qWarning() << "[AppImageLauncher] Warning:"
-                   << "fallback icons could not be loaded: directory could not be found";
+        std::cerr << "[AppImageLauncher] Warning:"
+                  << "fallback icons could not be loaded: directory could not be found" << std::endl;
         return QIcon{};
     }
 
@@ -1325,7 +1325,8 @@ QIcon loadIconWithFallback(const QString& iconName) {
     const auto iconPath = fallbackIconDirectory.filePath(iconFilename);
 
     if (!QFileInfo(iconPath).isFile()) {
-        qWarning() << "[AppImageLauncher] Warning: can't find fallback icon for name" << iconName;
+        std::cerr << "[AppImageLauncher] Warning: can't find fallback icon for name"
+                  << iconName.toStdString() << std::endl;
         return QIcon{};
     }
 

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -1256,6 +1256,33 @@ void checkAuthorizationAndShowDialogIfNecessary(const QString& path, const QStri
     }
 }
 
+QString pathToPrivateDataDirectory() {
+    // first we need to find the translation directory
+    // if this is run from the build tree, we try a path that can only work within the build directory
+    // then, we try the expected install location relative to the main binary
+    const auto binaryDirPath = QApplication::applicationDirPath();
+
+    // our helper tools are not shipped in usr/bin but usr/lib/<arch>-linux-gnu/appimagelauncher
+    // therefore we need to check for the translations directory relative to this directory as well
+    // as <arch-linux-gnu> may not be used in the path, we also check for its parent directory
+    QString dataDir = binaryDirPath + "/../../share/appimagelauncher/";
+
+    if (!QDir(dataDir).exists()) {
+        dataDir = binaryDirPath + "/../../../share/appimagelauncher/";
+    }
+
+    // this directory should work for the main application in usr/bin
+    if (!QDir(dataDir).exists()) {
+        dataDir = binaryDirPath + "/../share/appimagelauncher/";
+    }
+
+    if (!QDir(dataDir).exists()) {
+        return "";
+    }
+
+    return dataDir;
+}
+
 bool unregisterAppImage(const QString& pathToAppImage) {
     auto rv = appimage_unregister_in_system(pathToAppImage.toStdString().c_str(), false);
 

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -32,6 +32,7 @@ extern "C" {
 #include <QStandardPaths>
 #include <QWindow>
 #include <QPushButton>
+#include <QPixmap>
 #ifdef ENABLE_UPDATE_HELPER
 #include <appimage/update.h>
 #endif
@@ -1361,9 +1362,13 @@ void setUpFallbackIconPaths(QWidget* parent) {
         // load icon from theme, providing the bundled icon as a fallback
         // loading an "empty" (i.e., isNull() returns true) icon as fallback, as returned by loadIconWithFallback(...),
         // works just fine
-        const auto themeIcon = QIcon::fromTheme(iconName, loadIconWithFallback(iconName));
+        auto fallbackIcon = loadIconWithFallback(iconName);
+        auto newIcon = QIcon::fromTheme(iconName, fallbackIcon);
+
+        if (newIcon.isNull() || newIcon.pixmap(16, 16).isNull())
+            newIcon = fallbackIcon;
 
         // now replace the button's actual icon with the fallback-enabled one
-        button->setIcon(themeIcon);
+        button->setIcon(newIcon);
     }
 }

--- a/src/shared/shared.cpp
+++ b/src/shared/shared.cpp
@@ -1279,6 +1279,8 @@ QString pathToPrivateDataDirectory() {
     }
 
     if (!QDir(dataDir).exists()) {
+        std::cerr << "[AppImageLauncher] Warning: "
+                  << "Path to private data directory could not be found" << std::endl;
         return "";
     }
 

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -115,5 +115,9 @@ bool isAppImage(const QString& path);
 // the second argument is the question that will be asked in the dialog displayed in case a relaunch is necessary
 void checkAuthorizationAndShowDialogIfNecessary(const QString& path, const QString& question);
 
+// searchs for path to private data directory relative to the current binary's location
+// returns empty string if the path cannot be found
+QString pathToPrivateDataDirectory();
+
 // clean up desktop integration files installed while originally integrating the AppImage
 bool unregisterAppImage(const QString& pathToAppImage);

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -121,3 +121,11 @@ QString pathToPrivateDataDirectory();
 
 // clean up desktop integration files installed while originally integrating the AppImage
 bool unregisterAppImage(const QString& pathToAppImage);
+
+// try to load icon with provided name from AppImageLauncher's fallback icons directory
+// returns empty QIcon if such an icon cannot be found
+// you can check for errors by calling QIcon::isNull()
+QIcon loadIconWithFallback(const QString& iconName);
+
+// sets up paths to fallback icons bundled with AppImageLauncher
+void setUpFallbackIconPaths(QWidget*);

--- a/src/ui/first-run.cpp
+++ b/src/ui/first-run.cpp
@@ -145,6 +145,8 @@ public:
 void showFirstRunDialog() {
     auto dialog = new FirstRunDialog;
 
+    setUpFallbackIconPaths(dialog);
+
     auto rv = dialog->exec();
 
     if (rv <= 0) {

--- a/src/ui/remove_main.cpp
+++ b/src/ui/remove_main.cpp
@@ -84,8 +84,12 @@ int main(int argc, char** argv) {
 
     QDialog dialog;
     Ui::RemoveDialog ui;
+
     ui.setupUi(&dialog);
     ui.pathLabel->setText(pathToAppImage);
+
+    // must be done *after* loading the UI into the dialog
+    setUpFallbackIconPaths(&dialog);
 
     auto rv = dialog.exec();
 

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -73,7 +73,7 @@ void SettingsDialog::addDirectoryToWatchToListView(const QString& dirPath) {
 
     auto findIcon = [](const std::initializer_list<QString>& names) {
         for (const auto& i : names) {
-            auto icon = QIcon::fromTheme(i);
+            auto icon = QIcon::fromTheme(i, loadIconWithFallback(i));
 
             if (!icon.isNull())
                 return icon;

--- a/src/ui/settings_main.cpp
+++ b/src/ui/settings_main.cpp
@@ -3,6 +3,7 @@
 
 // local
 #include <translationmanager.h>
+#include <shared.h>
 #include "settings_dialog.h"
 
 int main(int argc, char** argv) {
@@ -11,8 +12,14 @@ int main(int argc, char** argv) {
     QApplication::setWindowIcon(QIcon(":/AppImageLauncher.svg"));
 
     TranslationManager mgr(app);
+//
+//    // we ship some very basic fallbacks for icons used in the settings dialog
+//    // this should fix missing icons on some distros
 
     SettingsDialog dialog;
+
+    setUpFallbackIconPaths(&dialog);
+
     dialog.show();
 
     return app.exec();


### PR DESCRIPTION
On some systems, the icons AppImageLauncher uses are missing. That's because the icon theme of the desktop doesn't provide them, leading to Qt showing empty buttons. For usability, that's of course a nightmare.

This PR introduces a fallback mechanism. We bundle the relevant icons with AppImageLauncher, and automatically load them as fallbacks. This way, there will be at least *some* icon. And even if it looks alien or even ugly (I didn't really invest a lot of time into making the SVGs), still, AppImageLauncher remains usable.

PRs with better icons are highly appreciated!