### PR TITLE
[binfmt-bypass] Fix child return code

### DIFF
--- a/src/binfmt-bypass/main.cpp
+++ b/src/binfmt-bypass/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char** argv) {
         child_retcode = WTERMSIG(status);
         log_error("child exited with code %d\n", child_retcode);
     } else if (WIFEXITED(status) != 0) {
-        child_retcode = status;
+        child_retcode = WEXITSTATUS(status);
         log_debug("child exited normally with code %d\n", child_retcode);
     } else {
         log_error("unknown error: child didn't exit with signal or regular exit code\n");


### PR DESCRIPTION
I created a [minimal AppImage](https://github.com/TheAssassin/AppImageLauncher/files/6341477/test.AppImage.gz) that contains a bash script exiting with status code `1`. Testing it with AIL built on commit 52d7ace, the AppImage exits with return code `0`.

I found this bug after noticing my tool [mttbernardini/appimage-updater](https://github.com/mttbernardini/appimage-updater) stopped working because of `appimageupdatetool-*.AppImage -j` always returning `0` even when updates were available.

For some reason this bug is related with a missing `WEXITSTATUS` macro, introduced in commit a14262a68cdc7b9febad127ea935b028ad343955.

This PR fixes the bug by reintroducing the missing macro.
