### PR TITLE
Update BUILD instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -12,7 +12,7 @@ You can download the source either using Git or by mannually downloading a tarba
 The branch can be customized by setting the `-b` or `--branch` argument. Select `stable` to download the current stable source or use `master` to get the most current unstable source containing the latest features.
 
 ```shell
-git clone https://github.com/TheAssassin/AppImageLauncher.git -b stable
+git clone https://github.com/TheAssassin/AppImageLauncher.git -b master
 cd AppImageLauncher
 git submodule update --init --recursive
 ```
@@ -55,8 +55,8 @@ make
 
 Now you may create a distribution package or alternatively install the source for testing purpose.
 
-*Note: This may harm your system. It's highly recommended to build and install distribution packages instead.*
+Directly running `make install` will carry a high risk of breaking your system, so it's suggested that you use `checkinstall` instead.  Install `checkinstall` with your system's package manager, and then run the installation via checkinstall.
 
 ```shell
-sudo make install
+sudo checkinstall
 ```


### PR DESCRIPTION
Maintainer of primary repo has said to use "Master" instead of the Stable branch because of dltray, etc. problems.  Further, `sudo make install` *can* in fact harm your system, but if you are on any mainstream distribution, `checkinstall` is actually available in most repositories and builds a native-package-manager-compatibile package around what `sudo make install` does and then *installs* that package so you can easily revert afterwards.  This tends to be the safer option.