### PR TITLE
Fix ARM64 arch name for rpm.

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -89,7 +89,11 @@ if [ "$ARCH" == "arm64" ]; then
         "-DCMAKE_C_COMPILER=clang-8"
         "-DCMAKE_CXX_COMPILER=clang++-8"
     )
+    # RPM-based Linux distributions use aarch64 instead of arm64 as ARM64 architecture name.
+    ARCH="aarch64"
 fi
+
+export CPACK_RPM_PACKAGE_ARCHITECTURE="${ARCH}"
 
 cmake "$REPO_ROOT" "${cmake_args[@]}" 
 


### PR DESCRIPTION
ARM64 arch name for rpm (aarch64) is different from deb (arm64). A related issue is https://github.com/jordansissel/fpm/pull/1775

This issue causes the appimagelauncher arm64 rpm can't be installed on Fedora Linux aarch64.
```
sudo rpm -i appimagelauncher-2.2.0-gha92.44cabe4.arm64.rpm 
	package appimagelauncher-2.2.0-gha92~44cabe4.arm64 is intended for a different architecture
sudo rpm -qi appimagelauncher-2.2.0-gha92.44cabe4.arm64.rpm |grep Arch
Architecture: arm64
```

It can confirm the normal rpm has aarch64 arch. For example, the one of Fedora rpm:
```
sudo rpm -qi http://free.nchc.org.tw/fedora/linux/updates/35/Everything/aarch64/Packages/a/at-3.2.5-3.fc35.aarch64.rpm|grep Arch
Architecture: aarch64

```

Thus, I try to modify the CI scripts for fixing this issue. However, I have no the same CI environment to confirm my changes work. Please try it.