### PR TITLE
Stop building xenial docker images

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -18,24 +18,12 @@ jobs:
           - NAME: bionic i386
             ARCH: i386
             DIST: bionic
-          - NAME: xenial x86_64
-            ARCH: x86_64
-            DIST: xenial
-          - NAME: xenial i386
-            ARCH: i386
-            DIST: xenial
           - NAME: bionic arm64
             ARCH: arm64
             DIST: bionic
           - NAME: bionic armhf
             ARCH: armhf
             DIST: bionic
-          - NAME: xenial arm64
-            ARCH: arm64
-            DIST: xenial
-          - NAME: xenial armhf
-            ARCH: armhf
-            DIST: xenial
           - NAME: Lite AppImage bionic x86_64
             ARCH: x86_64
             DIST: bionic


### PR DESCRIPTION
Commit 49346bbf25011da6d425cd7699af042c6f2c613a removed xenial docker images, but the CI still try to run them
This PR fix this