### PR TITLE
change + and - icons

### DIFF
--- a/src/ui/settings_dialog.ui
+++ b/src/ui/settings_dialog.ui
@@ -188,7 +188,8 @@
                <string>Add new directory to list</string>
               </property>
               <property name="icon">
-               <iconset theme="add"/>
+               <iconset theme="list-add">
+                <normaloff>.</normaloff>.</iconset>
               </property>
              </widget>
             </item>
@@ -201,7 +202,8 @@
                <string>Remove selected directory from list</string>
               </property>
               <property name="icon">
-               <iconset theme="remove"/>
+               <iconset theme="list-remove">
+                <normaloff>.</normaloff>.</iconset>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Hey, I've noticed the + icon doesn't appear in my environment (ArchLinux KDE), and that the - icon appear for some reason even if Qt Creator doesn't mention it in the icons list

I've replaced them with elements that *were* in the list of icons

I tested the changes in ZorinOS 18.04 (running an Gnome environment IIRC) and Debian 11 running XFCE and the modified icons appear in both of them (plus in my own environment ofc)

