### PR TITLE
daemon: Log missing dirs as debug message

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -89,7 +89,7 @@ namespace appimagelauncher::daemon {
 
         for (const auto& dir : dirsToSearch) {
             if (!dir.exists()) {
-                qCInfo(daemonCat) << "Directory " << dir.path() << " does not exist, skipping";
+                qDebug() << "Directory " << dir.path() << " does not exist, skipping";
                 continue;
             }
 


### PR DESCRIPTION
On Linux, the daemon is endlessly logging into the journal about the nonexistence of an `/Applications` directory:

```text
Mar 26 12:41:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:42:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:42:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:43:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:43:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:44:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:44:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:45:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:45:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:46:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:46:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:47:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:47:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:48:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:48:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:49:26 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
Mar 26 12:49:56 appimagelauncherd[1992100]: Directory /Applications does not exist, skipping
```

But that directory (which is hardcoded onto the list in `src/shared/shared.cpp`):
https://github.com/TheAssassin/AppImageLauncher/blob/71e8e32c095cd5ca78169f186a857a722972a3ce/src/shared/shared.cpp#L320-L324

...is expected not to exist, on Linux. So, move that message from `qCInfo(daemonCat)` to `qDebug()`.