### PR TITLE
Add support for static runtimes

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -45,6 +45,8 @@ cmake_args=(
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
     "-DBUILD_TESTING=OFF"
     "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+    # TODO: we don't necessarily want to hardcode this here
+    "-DBINFMT_INTERPRETER_PATH_PREPEND_LD_P_NATIVE_PACKAGES_PREFIX=/opt/appimagelauncher.AppDir/"
 )
 
 if [[ "${BUILD_LITE:-}" == "" ]]; then

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -43,10 +43,17 @@ if(ENABLE_UPDATE_HELPER)
     )
 endif()
 
+option(BINFMT_INTERPRETER_PATH_PREPEND_LD_P_NATIVE_PACKAGES_PREFIX "")
+
 if(NOT BUILD_LITE)
     # unfortunately, due to a cyclic dependency, we need to hardcode parts of this variable, which is included in the
     # install scripts and the binfmt.d config
     set(BINFMT_INTERPRETER_PATH ${CMAKE_INSTALL_PREFIX}/${_private_libdir}/binfmt-interpreter)
+
+    if(BINFMT_INTERPRETER_PATH_PREPEND_LD_P_NATIVE_PACKAGES_PREFIX)
+        message(STATUS "Prepending prefix ${BINFMT_INTERPRETER_PATH_PREPEND_LD_P_NATIVE_PACKAGES_PREFIX} to binfmt interpreter path")
+        set(BINFMT_INTERPRETER_PATH "${BINFMT_INTERPRETER_PATH_PREPEND_LD_P_NATIVE_PACKAGES_PREFIX}${BINFMT_INTERPRETER_PATH}")
+    endif()
 
     # according to https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html, we must make sure the
     # interpreter string does not exceed 127 characters

--- a/resources/install-scripts/post-install.in
+++ b/resources/install-scripts/post-install.in
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
 echo "Installing AppImageLauncher as interpreter for AppImages"
 

--- a/resources/install-scripts/post-uninstall.in
+++ b/resources/install-scripts/post-uninstall.in
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -eo pipefail
+set -euo pipefail
 
 echo "Removing AppImageLauncher as interpreter for AppImages"
 (set -x; systemctl restart systemd-binfmt)

--- a/src/binfmt-bypass/CMakeLists.txt
+++ b/src/binfmt-bypass/CMakeLists.txt
@@ -120,14 +120,14 @@ target_link_libraries(${bypass_lib} PUBLIC dl)
 # we need to include the preload lib headers (see below) from the binary dir
 target_include_directories(${bypass_lib} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_options(${bypass_lib}
-    PRIVATE -DPRELOAD_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${_private_libdir}/$<TARGET_FILE_NAME:${preload_lib}>"
+    PRIVATE -DPRELOAD_LIB_NAME="$<TARGET_FILE_NAME:${preload_lib}>"
     PUBLIC -D_GNU_SOURCE
     # obviously needs to be private, otherwise the value leaks into users of this lib
     PRIVATE -DCOMPONENT_NAME="lib"
 )
 if(build_32bit_preload_library)
     target_compile_options(${bypass_lib}
-        PRIVATE -DPRELOAD_LIB_PATH_32BIT="${CMAKE_INSTALL_PREFIX}/${_private_libdir}/$<TARGET_FILE_NAME:${preload_lib_32bit}>"
+        PRIVATE -DPRELOAD_LIB_NAME_32BIT="$<TARGET_FILE_NAME:${preload_lib_32bit}>"
     )
     target_sources(${bypass_lib} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${preload_lib_32bit}.h)
 endif()

--- a/src/binfmt-bypass/elf.cpp
+++ b/src/binfmt-bypass/elf.cpp
@@ -164,7 +164,7 @@ bool is_32bit_elf(const std::string& filename) {
     std::ifstream ifs(filename);
 
     if (!ifs) {
-        log_error("could not open file\n");
+        log_error("could not open file: %s\n", filename.c_str());
         return -1;
     }
 

--- a/src/binfmt-bypass/elf.cpp
+++ b/src/binfmt-bypass/elf.cpp
@@ -92,6 +92,49 @@ off_t get_elf_size(std::ifstream& ifs)
     return sht_end > last_section_end ? sht_end : last_section_end;
 }
 
+template<typename EhdrT, typename ShdrT>
+ssize_t get_pt_dynamic_offset(std::ifstream& ifs)
+{
+    static_assert(std::is_same<Elf64_Ehdr, EhdrT>::value || std::is_same<Elf32_Ehdr, EhdrT>::value,
+                  "must be Elf{32,64}_Ehdr");
+    static_assert(std::is_same<Elf64_Shdr, ShdrT>::value || std::is_same<Elf32_Shdr, ShdrT>::value,
+                  "must be Elf{32,64}_Shdr");
+
+    EhdrT elf_header{};
+
+    ifs.seekg(0, std::ifstream::beg);
+    ifs.read(reinterpret_cast<char*>(&elf_header), sizeof(elf_header));
+
+    if (!ifs) {
+        log_error("failed to read ELF header\n");
+        return -1;
+    }
+
+    swap_data_if_necessary(elf_header, elf_header.e_shoff);
+    swap_data_if_necessary(elf_header, elf_header.e_shentsize);
+    swap_data_if_necessary(elf_header, elf_header.e_shnum);
+    swap_data_if_necessary(elf_header, elf_header.e_shnum);
+
+    off_t last_shdr_offset = elf_header.e_shoff + (elf_header.e_shentsize * (elf_header.e_shnum - 1));
+    ShdrT section_header{};
+
+    ifs.seekg(last_shdr_offset, std::ifstream::beg);
+    ifs.read(reinterpret_cast<char*>(&section_header), sizeof(elf_header));
+
+    if (!ifs) {
+        log_error("failed to read ELF section header\n");
+        return -1;
+    }
+
+    swap_data_if_necessary(elf_header, section_header.sh_offset);
+    swap_data_if_necessary(elf_header, section_header.sh_size);
+
+    /* ELF ends either with the table of section headers (SHT) or with a section. */
+    off_t sht_end = elf_header.e_shoff + (elf_header.e_shentsize * elf_header.e_shnum);
+    off_t last_section_end = section_header.sh_offset + section_header.sh_size;
+    return sht_end > last_section_end ? sht_end : last_section_end;
+}
+
 bool is_32bit_elf(std::ifstream& ifs) {
     if (!ifs) {
         log_error("failed to read e_ident from ELF file\n");
@@ -126,6 +169,34 @@ bool is_32bit_elf(const std::string& filename) {
     }
 
     return is_32bit_elf(ifs);
+}
+
+bool is_statically_linked_elf(std::ifstream& ifs) {
+    if (!ifs) {
+        log_error("failed to read e_ident from ELF file\n");
+        return -1;
+    }
+
+    ssize_t pt_dynamic_offset;
+
+    if (is_32bit_elf(ifs)) {
+        pt_dynamic_offset = get_pt_dynamic_offset<Elf32_Ehdr, Elf32_Shdr>(ifs);
+    } else {
+        pt_dynamic_offset = get_pt_dynamic_offset<Elf64_Ehdr, Elf64_Shdr>(ifs);
+    }
+
+    return pt_dynamic_offset != -1;
+}
+
+bool is_statically_linked_elf(const std::string& filename) {
+    std::ifstream ifs(filename);
+
+    if (!ifs) {
+        log_error("could not open file: %s\n", filename.c_str());
+        return -1;
+    }
+
+    return is_statically_linked_elf(ifs);
 }
 
 ssize_t elf_binary_size(const std::string& filename) {

--- a/src/binfmt-bypass/elf.h
+++ b/src/binfmt-bypass/elf.h
@@ -3,6 +3,13 @@
 #include <string>
 
 /**
+ * Check whether file is linked staticallly.
+ * @param filename path to ELF file
+ * @return true if file is statically linked, false otherwise
+ */
+bool is_statically_linked_elf(const std::string& filename);
+
+/**
  * Calculate size of ELF binary. Useful e.g., to estimate the size of the runtime in an AppImage.
  * @param filename path to ELF file
  * @return size of ELF part in bytes

--- a/src/binfmt-bypass/interpreter_main.cpp
+++ b/src/binfmt-bypass/interpreter_main.cpp
@@ -33,7 +33,6 @@ int main(int argc, char** argv) {
     if (!executableExists(APPIMAGELAUNCHER_PATH)) {
         log_message(
             "AppImageLauncher not found at %s, launching AppImage directly: %s\n",
-            APPIMAGELAUNCHER_PATH,
             appImagePath.c_str()
         );
         useAppImageLauncher = false;
@@ -42,7 +41,6 @@ int main(int argc, char** argv) {
     if (getenv("APPIMAGELAUNCHER_DISABLE") != nullptr) {
         log_message(
             "APPIMAGELAUNCHER_DISABLE set, launching AppImage directly: %s\n",
-            APPIMAGELAUNCHER_PATH,
             appImagePath.c_str()
         );
         useAppImageLauncher = false;

--- a/src/binfmt-bypass/lib.cpp
+++ b/src/binfmt-bypass/lib.cpp
@@ -238,11 +238,13 @@ int bypassBinfmtAndRunAppImage(const std::string& appimage_path, const std::vect
         // preload our library
         auto preload_lib_path = find_preload_library(is_32bit_elf(appimage_path));
 
+        log_debug("preload lib path: %s\n", preload_lib_path.string().c_str());
+
         // may or may not be used, but must survive until this application terminates
         std::unique_ptr<TemporaryPreloadLibFile> temporaryPreloadLibFile;
 
         if (!std::filesystem::exists(preload_lib_path)) {
-            log_warning("could not find preload library path, creating new temporary file for it\n");
+            log_warning("could not find preload library, creating new temporary file for it\n");
 
 #ifdef PRELOAD_LIB_NAME_32BIT
             if (is_32bit_elf(appimage_path)) {

--- a/src/binfmt-bypass/preload.c
+++ b/src/binfmt-bypass/preload.c
@@ -61,7 +61,7 @@ void __init() {
 char* __abs_appimage_path() {
     __init();
 
-    static const char env_var_name[] = "REDIRECT_APPIMAGE";
+    static const char env_var_name[] = "TARGET_APPIMAGE";
 
     char* appimage_var = getenv(env_var_name);
 


### PR DESCRIPTION
Work in progress to properly support the new static runtimes.

Please note that this likely only works for AppImages built with the official(!) runtime, since it relies on its undocumented `$TARGET_APPIMAGE` feature. Said feature is subject to be included in the AppImage spec. See https://github.com/AppImage/AppImageSpec/issues/38.

Also, support relies on the runtime being linked as a PIE. See https://github.com/AppImage/AppImageSpec/issues/48. The official runtime is built that way, others might not.

Fixes #585.