### PR TITLE
Add command-line symlinks with simplified names feature

### DIFF
--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -66,7 +66,7 @@ IntegrationState integrateAppImage(const QString& pathToAppImage, const QString&
 // < 0: unset; 0 = false; > 0 = true
 // destination is a string that, when empty, will be interpreted as "use default"
 void createConfigFile(int askToMove, const QString& destination, int enableDaemon,
-                      const QStringList& additionalDirsToWatch = {}, int monitorMountedFilesystems = -1);
+                      const QStringList& additionalDirsToWatch = {}, int monitorMountedFilesystems = -1, int createCliSymlinks = -1, int useSimplifiedNames = -1);
 
 // replaces ~ character in paths with real home directory, if necessary and possible
 QString expandTilde(QString path);
@@ -131,3 +131,70 @@ QIcon loadIconWithFallback(const QString& iconName);
 
 // sets up paths to fallback icons bundled with AppImageLauncher
 void setUpFallbackIconPaths(QWidget*);
+
+/**
+ * Crée un lien symbolique dans ~/.local/bin pour une AppImage
+ * @param pathToAppImage Chemin vers l'AppImage
+ * @return true si le lien a été créé avec succès, false sinon
+ */
+bool createSymlinkInPath(const QString& pathToAppImage);
+
+/**
+ * Supprime le lien symbolique correspondant à une AppImage
+ * @param pathToAppImage Chemin vers l'AppImage
+ * @return true si le lien a été supprimé avec succès, false sinon
+ */
+bool removeSymlinkFromPath(const QString& pathToAppImage);
+
+/**
+ * Vérifie si ~/.local/bin est dans le PATH de l'utilisateur
+ * @return true si ~/.local/bin est dans le PATH, false sinon
+ */
+bool isLocalBinInPath();
+
+/**
+ * Synchronise les liens symboliques pour toutes les AppImages intégrées
+ * en fonction de la configuration actuelle
+ * @return true si la synchronisation a réussi, false sinon
+ */
+bool synchronizeSymlinksForIntegratedAppImages();
+
+/**
+ * Extrait un nom de commande approprié depuis une AppImage
+ * @param pathToAppImage Chemin vers l'AppImage
+ * @return Nom de commande convenable (sans espaces ni caractères spéciaux)
+ */
+QString extractCommandName(const QString& pathToAppImage);
+
+/**
+ * Assainit un nom pour en faire un nom de commande valide
+ * @param name Nom brut
+ * @return Nom assaini pour utilisation en ligne de commande
+ */
+QString sanitizeCommandName(const QString& name);
+
+/**
+ * Obtient le chemin vers le fichier de configuration des mappages de noms de commande
+ * @return Chemin vers le fichier de configuration
+ */
+QString getCommandNameMappingFilePath();
+
+/**
+ * Enregistre la liaison entre une AppImage et son nom de commande simplifié
+ * @param pathToAppImage Chemin vers l'AppImage
+ * @param commandName Nom de commande simplifié
+ */
+void registerCommandNameMapping(const QString& pathToAppImage, const QString& commandName);
+
+/**
+ * Récupère le nom de commande simplifié pour une AppImage
+ * @param pathToAppImage Chemin vers l'AppImage
+ * @return Nom de commande simplifié ou chaîne vide si non trouvé
+ */
+QString getCommandNameMapping(const QString& pathToAppImage);
+
+/**
+ * Supprime la liaison entre une AppImage et son nom de commande
+ * @param pathToAppImage Chemin vers l'AppImage
+ */
+void removeCommandNameMapping(const QString& pathToAppImage);

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -99,10 +99,14 @@ void SettingsDialog::addDirectoryToWatchToListView(const QString& dirPath) {
 void SettingsDialog::loadSettings() {
     const auto daemonIsEnabled = settingsFile->value("AppImageLauncher/enable_daemon", "true").toBool();
     const auto askMoveChecked = settingsFile->value("AppImageLauncher/ask_to_move", "true").toBool();
+    const auto createCliSymlinks = settingsFile->value("AppImageLauncher/create_cli_symlinks", "true").toBool();
+    const auto useSimplifiedNames = settingsFile->value("AppImageLauncher/use_simplified_names", "true").toBool();
 
     if (settingsFile) {
         ui->daemonIsEnabledCheckBox->setChecked(daemonIsEnabled);
         ui->askMoveCheckBox->setChecked(askMoveChecked);
+        ui->createCliSymlinksCheckBox->setChecked(createCliSymlinks);
+        ui->useSimplifiedNamesCheckBox->setChecked(useSimplifiedNames);
         ui->applicationsDirLineEdit->setText(settingsFile->value("AppImageLauncher/destination").toString());
 
         const auto additionalDirsPath = settingsFile->value("appimagelauncherd/additional_directories_to_watch", "").toString();
@@ -148,10 +152,15 @@ void SettingsDialog::saveSettings() {
                      ui->applicationsDirLineEdit->text(),
                      ui->daemonIsEnabledCheckBox->isChecked(),
                      additionalDirsToWatch,
-                     monitorMountedFilesystems);
+                     monitorMountedFilesystems,
+                     ui->createCliSymlinksCheckBox->isChecked(),
+                     ui->useSimplifiedNamesCheckBox->isChecked());
 
     // reload settings
     loadSettings();
+    
+    // Synchroniser les liens symboliques pour les AppImages déjà intégrées
+    synchronizeSymlinksForIntegratedAppImages();
 }
 
 void SettingsDialog::toggleDaemon() {

--- a/src/ui/settings_dialog.ui
+++ b/src/ui/settings_dialog.ui
@@ -37,6 +37,26 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="createCliSymlinksCheckBox">
+            <property name="text">
+             <string>Create command-line shortcuts in ~/.local/bin for integrated AppImages</string>
+            </property>
+            <property name="toolTip">
+             <string>Allows you to run integrated AppImages directly from the terminal</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="useSimplifiedNamesCheckBox">
+            <property name="text">
+             <string>Use simplified names for command-line shortcuts</string>
+            </property>
+            <property name="toolTip">
+             <string>Creates commands with simple names like "krita" instead of complex hash-based names</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
This PR adds two new features to facilitate the use of integrated AppImages from the terminal:

1. **Creation of symbolic links in ~/.local/bin** for integrated AppImages, allowing them to be launched from the terminal.
2. **Use of simplified names** for these links (like "cursor" instead of "Cursor-0_48_9-x86_64_0ec6c12a061af79a840403cc4b4ab235").

The new features include:
- Configurable options in the settings user interface
- Logic for handling name conflicts (with numeric suffixes)
- Automatic synchronization of links when integrating/disintegrating AppImages
- Verification of ~/.local/bin presence in PATH

These features have been successfully tested with several AppImages (Cursor, Krita, Audacity).