### PR TITLE
Update minimum required CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(AppImageLauncher)
 


### PR DESCRIPTION
When building AppImageLauncher, I came across the error:

```console
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

The error shows when I use CMake v4.0.2, but not when I switch back to v3.31.7. Updating the minimum version to 3.5 fixed the issue for me.

- CMake 3.5.0 was announced on [March 8, 2016](https://cmake.org/pipermail/cmake/2016-March/062947.html)
- CMake 3.2.0-rc1 was announced on [February 13, 2015](https://cmake.org/pipermail/cmake/2015-February/059859.html)

I have also made a [PR for AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate/pull/250).
