### PR TITLE
Fix arm64 arch name

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -119,8 +119,8 @@ if [[ "${BUILD_LITE:-}" == "" ]]; then
             deb_build_arch=i386
             ;;
         aarch64)
-            rpm_build_arch=arm64
-            deb_build_arch=aarch64
+            rpm_build_arch=aarch64
+            deb_build_arch=arm64
             ;;
         armhf)
             deb_build_arch=armhf


### PR DESCRIPTION
These two in (3.0 beta releases) filename are reversed.

- https://wiki.debian.org/Multiarch/Tuples#Architectures_in_Debian
- https://fedoraproject.org/wiki/Architectures

But I'm not sure if this variable is used anywhere except in the file name, so check it carefully.