### PR TITLE
Compatibility table update

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,7 @@ Compatibility table (likely incomplete.) Please, feel free to open PRs to add di
 | `appimagelauncher-<version>.bionic_(amd64,i386).deb` | Ubuntu Bionic (18.04) and newer, LMDE 6 "Faye" |
 | `appimagelauncher-<version>.(i386,x86_64).rpm`       | rpm-based | openSUSE Leap 42 and newer, possibly openSUSE Tumbleweed, SUSE Enterprise Linux, RHEL 7, CentOS 7 |
 
-
-Note: Ubuntu Bionic (and newer) broke with the backwards compatibility of its `libcurl` packages, therefore users of these systems need to install the special `bionic` package
-
-
-Manjaro and Netrunner Rolling users can install AppImageLauncher with a distribution-provided package called `appimagelauncher`.
+The reason there are two ubuntu packages is because ubuntu Bionic (and newer) broke with the backwards compatibility of its `libcurl` packages, therefore users of these systems need to install the special `bionic` package.
 
 Arch Linux, Manjaro, Antergos and Netrunner Rolling users can use AUR to install AppImageLauncher by installing [appimagelauncher](https://aur.archlinux.org/packages/appimagelauncher) or [appimagelauncher-git](https://aur.archlinux.org/packages/appimagelauncher-git) (possibly broken, see [#574](https://github.com/TheAssassin/AppImageLauncher/issues/574)) (thanks @NuLogicSystems for setting up the build). 
 


### PR DESCRIPTION
I recently installed the app in ubuntu 24.04 using the deb package. However, I had a hard time deciphering the compatibility table. From the discussions, seems like I'm not the only one confused by the version that should be used (eg https://github.com/TheAssassin/AppImageLauncher/discussions/642#discussioncomment-10411184). 

This PR attempts to clean the table a little bit:

- simplify version lists: ubuntu bionic now lists simply "18.04 and newer", plus the text below on why there are two ubuntu versions is more understandable
- remove non-existing packages: disco, eoan, and buster don't seem to exist, and indeed were striked in the table. Removed so that they don't add to the confusion
- fix system build for rpm systems in the table, which was wrong
- remove trailing ul of distributions that were totally out of context (probably leftover from previous edits?)
- remove info about the PPAs, since they are now discontinued 
- deduplicate redundant paragraph about AUR package 
- deduplicate redundant paragraph about compatibility of similar systems (now at the end)

Hopefully, this makes things easier to follow.