### PR TITLE
feat(qt6): update cmake and qt versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(AppImageLauncher)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,4 @@
-# in version 3.6 IMPORTED_TARGET has been added to pkg_*_modules
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -16,7 +15,7 @@ set(CMAKE_AUTOUIC ON)
 # Compile resource files
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets DBus Quick QuickWidgets Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets DBus Quick QuickWidgets Qml)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(glib REQUIRED glib-2.0>=2.40 IMPORTED_TARGET)

--- a/src/binfmt-bypass/CMakeLists.txt
+++ b/src/binfmt-bypass/CMakeLists.txt
@@ -1,5 +1,4 @@
-# needed for LINK_OPTIONS/target_link_options
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 project(appimage-binfmt-bypass)
 
@@ -51,11 +50,7 @@ function(make_preload_lib_target target_name)
         # hide all symbols by default
         PRIVATE -fvisibility=hidden
     )
-    # compatibility with CMake < 3.13
-    set_target_properties(${target_name} PROPERTIES LINK_OPTIONS
-        # hide all symbols by default
-        -fvisibility=hidden
-    )
+    target_link_options(${target_name} PRIVATE -fvisibility=hidden)
 
     # a bit of a hack, but it seems to make binfmt bypass work in really old Docker images (e.g., CentOS <= 7)
     add_custom_command(

--- a/src/cli/commands/CMakeLists.txt
+++ b/src/cli/commands/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(cli_commands STATIC
     UnintegrateCommand.h UnintegrateCommand.cpp
     WouldIntegrateCommand.h WouldIntegrateCommand.cpp
 )
-target_link_libraries(cli_commands PUBLIC Qt5::Core shared cli_logging libappimage)
+target_link_libraries(cli_commands PUBLIC Qt6::Core shared cli_logging libappimage)
 target_include_directories(cli_commands PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/cli/logging/logging.h
+++ b/src/cli/logging/logging.h
@@ -4,6 +4,7 @@
 #include <string.h>
 
 // library headers
+#include <QIODevice>
 #include <QTextStream>
 #include <QDebug>
 
@@ -12,3 +13,6 @@
 
 // wrapper for stderr
 #define qerr() QTextStream(stderr, QIODevice::WriteOnly)
+
+// Qt6 moved endl to Qt namespace
+using Qt::endl;

--- a/src/fswatcher/CMakeLists.txt
+++ b/src/fswatcher/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(filesystemwatcher STATIC filesystemwatcher.cpp filesystemwatcher.h)
-target_link_libraries(filesystemwatcher PUBLIC Qt5::Core shared)
+target_link_libraries(filesystemwatcher PUBLIC Qt6::Core shared)
 target_include_directories(filesystemwatcher PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/i18n/CMakeLists.txt
+++ b/src/i18n/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(translationmanager translationmanager.cpp translationmanager.h)
-target_link_libraries(translationmanager PUBLIC Qt5::Core Qt5::Widgets shared)
+target_link_libraries(translationmanager PUBLIC Qt6::Core Qt6::Widgets shared)
 target_include_directories(translationmanager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(translationmanager l10n)

--- a/src/i18n/translationmanager.cpp
+++ b/src/i18n/translationmanager.cpp
@@ -14,7 +14,7 @@
 TranslationManager::TranslationManager(QCoreApplication& app) : app(app) {
     // set up translations
     auto qtTranslator = new QTranslator();
-    qtTranslator->load("qt_" + QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    qtTranslator->load("qt_" + QLocale::system().name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath));
     app.installTranslator(qtTranslator);
 
     const auto systemLocale = QLocale::system().name();

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(shared STATIC shared.h shared.cpp types.h types.cpp)
-target_link_libraries(shared PUBLIC PkgConfig::glib Qt5::Core Qt5::Widgets Qt5::DBus libappimage translationmanager trashbin)
+target_link_libraries(shared PUBLIC PkgConfig::glib Qt6::Core Qt6::Widgets Qt6::DBus libappimage translationmanager trashbin)
 if(ENABLE_UPDATE_HELPER)
     target_link_libraries(shared PUBLIC libappimageupdate)
 endif()

--- a/src/trashbin/CMakeLists.txt
+++ b/src/trashbin/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(trashbin STATIC trashbin.cpp trashbin.h)
-target_link_libraries(trashbin PUBLIC Qt5::Core libappimage shared)
+target_link_libraries(trashbin PUBLIC Qt6::Core libappimage shared)
 target_include_directories(translationmanager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -48,7 +48,7 @@ install(
 # AppImage update helper
 if(ENABLE_UPDATE_HELPER)
     add_executable(update update.ui update_main.cpp resources.qrc)
-    target_link_libraries(update shared translationmanager libappimage libappimageupdate-qt Qt5::Quick Qt5::QuickWidgets Qt5::Qml)
+    target_link_libraries(update shared translationmanager libappimage libappimageupdate-qt Qt6::Quick Qt6::QuickWidgets Qt6::Qml)
     # see AppImageLauncher for a description
     set_target_properties(update PROPERTIES INSTALL_RPATH "\$ORIGIN")
 

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -171,7 +171,7 @@ void SettingsDialog::toggleDaemon() {
 void SettingsDialog::onChooseAppsDirClicked() {
     QFileDialog fileDialog(this);
 
-    fileDialog.setFileMode(QFileDialog::DirectoryOnly);
+    fileDialog.setFileMode(QFileDialog::Directory);
     fileDialog.setWindowTitle(tr("Select Applications directory"));
     fileDialog.setDirectory(integratedAppImagesDestination().absolutePath());
 
@@ -188,7 +188,7 @@ void SettingsDialog::onChooseAppsDirClicked() {
 void SettingsDialog::onAddDirectoryToWatchButtonClicked() {
     QFileDialog fileDialog(this);
 
-    fileDialog.setFileMode(QFileDialog::DirectoryOnly);
+    fileDialog.setFileMode(QFileDialog::Directory);
     fileDialog.setWindowTitle(tr("Select additional directory to watch"));
     fileDialog.setDirectory(QStandardPaths::locate(QStandardPaths::HomeLocation, ".", QStandardPaths::LocateDirectory));
 


### PR DESCRIPTION
This PR represents the minimum set of changes necessary to properly build and use AppImageLauncher in 2026 on modern systems:
- CMAKE minimum version is now 3.16
- Qt6 instead of Qt5

Minimal actual changes to code, mostly just to CMakeList.txt files