### PR TITLE
Fix library include path for remover/updater

### DIFF
--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -29,6 +29,16 @@ set(_abs_private_libdir ${CMAKE_INSTALL_PREFIX}/${_private_libdir})
 file(RELATIVE_PATH _rpath ${_abs_bindir} ${_abs_private_libdir})
 set(_rpath "\$ORIGIN/${_rpath}")
 
+# in addition to $ORIGIN, binaries/libraries living in the private libdir need to be able to find the libraries
+# linuxdeploy bundles when deploying the AppDir (e.g., libgpgme, libgpg-error, libassuan pulled in transitively by
+# libappimageupdate). Linuxdeploy always places those in the *flat* usr/lib. Without this, those libraries silently fail
+# to load at runtime (see the remove/update targets for the executable side)
+set(_abs_flat_libdir ${CMAKE_INSTALL_PREFIX}/lib)
+file(RELATIVE_PATH _rpath_flat_libdir ${_abs_private_libdir} ${_abs_flat_libdir})
+set(_rpath_flat_libdir "\$ORIGIN/${_rpath_flat_libdir}")
+
+set_target_properties(libappimage PROPERTIES INSTALL_RPATH "\$ORIGIN;${_rpath_flat_libdir}")
+
 # install libappimage.so into lib/appimagekit to avoid overwriting a libappimage potentially installed into /usr/lib
 # or /usr/lib/x86_64-... or wherever the OS puts its libraries
 install(
@@ -37,6 +47,8 @@ install(
 )
 
 if(ENABLE_UPDATE_HELPER)
+    set_target_properties(libappimageupdate libappimageupdate-qt PROPERTIES INSTALL_RPATH "\$ORIGIN;${_rpath_flat_libdir}")
+
     install(
         TARGETS libappimageupdate libappimageupdate-qt
         LIBRARY DESTINATION "${_private_libdir}" COMPONENT APPIMAGELAUNCHER

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -36,7 +36,11 @@ install(
 add_executable(remove remove_main.cpp remove.ui resources.qrc)
 target_link_libraries(remove shared translationmanager libappimage)
 # see AppImageLauncher for a description
-set_target_properties(remove PROPERTIES INSTALL_RPATH "\$ORIGIN")
+# in addition to $ORIGIN (where libappimage.so etc. are installed to), we also need the flat lib dir (see
+# _rpath_flat_libdir in install.cmake), as that's where linuxdeploy bundles transitive dependencies (e.g.,
+# libgpgme, libgpg-error, libassuan pulled in by libappimageupdate) when deploying the AppDir; without it, those
+# libraries silently fail to load at runtime
+set_target_properties(remove PROPERTIES INSTALL_RPATH "\$ORIGIN;${_rpath_flat_libdir}")
 
 install(
     TARGETS
@@ -49,8 +53,8 @@ install(
 if(ENABLE_UPDATE_HELPER)
     add_executable(update update.ui update_main.cpp resources.qrc)
     target_link_libraries(update shared translationmanager libappimage libappimageupdate-qt Qt5::Quick Qt5::QuickWidgets Qt5::Qml)
-    # see AppImageLauncher for a description
-    set_target_properties(update PROPERTIES INSTALL_RPATH "\$ORIGIN")
+    # see remove target above for a description of why the flat lib dir is included, too
+    set_target_properties(update PROPERTIES INSTALL_RPATH "\$ORIGIN;${_rpath_flat_libdir}")
 
     install(
         TARGETS


### PR DESCRIPTION
This PR represents the minimum set of changes necessary to properly include shared libraries required by the remove/update tools into the private libdir. This bug prevented the removal of AppImages when using the default remove action specified in the .desktop file, as it silently fails due to the missing libraries (tested on Ubuntu 26.04).

No actual changes to code, just to CMakeList.txt files.